### PR TITLE
Mark studiocms-devapps as released in package catalog

### DIFF
--- a/.github/workflows/ci-pr-lunaria-overview.yml
+++ b/.github/workflows/ci-pr-lunaria-overview.yml
@@ -24,5 +24,4 @@ jobs:
       - name: Generate Lunaria Overview
         uses: lunariajs/action@astro-docs
         with:
-          working-directory: docs
           token: ${{ secrets.STUDIOCMS_SERVICE_TOKEN }}

--- a/src/content/package-catalog/studiocms-devapps.json
+++ b/src/content/package-catalog/studiocms-devapps.json
@@ -5,6 +5,6 @@
   "docsLink": "/package-catalog/studiocms-plugins/studiocms-devapps/",
   "githubURL": "https://github.com/withstudiocms/studiocms/tree/main/packages/studiocms_devapps/",
   "catalog": "studiocms",
-  "released": false,
+  "released": true,
   "publiclyUsable": true
 }


### PR DESCRIPTION
This pull request includes a small but significant change to the `src/content/package-catalog/studiocms-devapps.json` file. The change marks the `studiocms-devapps` package as released.

* [`src/content/package-catalog/studiocms-devapps.json`](diffhunk://#diff-2b83de617b31e4c0d9c76884c891c578bfbdf7f960fe28e403209a5dba164913L8-R8): Updated the `released` field from `false` to `true`.