### PR TITLE
Update lunaria-report-bot.ts

### DIFF
--- a/.github/workflows/ci-report-lunaria.yml
+++ b/.github/workflows/ci-report-lunaria.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Send a Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_I18N_REPORT }}
-          DISCORD_EMBEDS: ${{ toJson(steps.message.outputs.DISCORD_MESSAGE_EMBEDS) }}
         uses: Ilshidur/action-discord@0.3.2
         with:
           args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"

--- a/.github/workflows/ci-report-lunaria.yml
+++ b/.github/workflows/ci-report-lunaria.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Send a Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_I18N_REPORT }}
-          DISCORD_EMBEDS: ${{ steps.message.outputs.DISCORD_MESSAGE_EMBEDS }}
+          DISCORD_EMBEDS: ${{ toJson(steps.message.outputs.DISCORD_MESSAGE_EMBEDS) }}
         uses: Ilshidur/action-discord@0.3.2
         with:
           args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"

--- a/.github/workflows/ci-report-lunaria.yml
+++ b/.github/workflows/ci-report-lunaria.yml
@@ -23,12 +23,10 @@ jobs:
         name: Format Discord message
         run: pnpm ci:lunaria:report
 
-  discord_message:
-    name: Send Discord Message
-    uses: withstudiocms/automations/.github/workflows/discord-msg.yml@main
-    needs: translation
-    secrets:
-      DISCORD_WEBHOOK: ${{ secrets.DISCORD_I18N_REPORT }}
-    with:
-      DISCORD_MESSAGE: ${{ needs.translation.outputs.DISCORD_MESSAGE }}
-      DISCORD_MESSAGE_EMBEDS: ${{ needs.translation.outputs.DISCORD_MESSAGE_EMBEDS }}
+      - name: Send a Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_I18N_REPORT }}
+          DISCORD_EMBEDS: ${{ steps.message.outputs.DISCORD_MESSAGE_EMBEDS }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: "${{ steps.message.outputs.DISCORD_MESSAGE }}"

--- a/scripts/lunaria-report-bot.ts
+++ b/scripts/lunaria-report-bot.ts
@@ -11,13 +11,11 @@ async function setDiscordMessage() {
 
 	if (!status) return;
 
-	const toTranslate = status;
-
-	/* .filter(
+	const toTranslate = status.filter(
 		(s) =>
 			new Date(s.source.git.latestTrackedChange.date) >
 			new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-	); */
+	);
 
 	const list = toTranslate
 		.filter(

--- a/scripts/lunaria-report-bot.ts
+++ b/scripts/lunaria-report-bot.ts
@@ -11,11 +11,13 @@ async function setDiscordMessage() {
 
 	if (!status) return;
 
-	const toTranslate = status.filter(
+	const toTranslate = status;
+
+	/* .filter(
 		(s) =>
 			new Date(s.source.git.latestTrackedChange.date) >
 			new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-	);
+	); */
 
 	const list = toTranslate
 		.filter(
@@ -45,10 +47,23 @@ async function setDiscordMessage() {
 			})`;
 		})
 		.join('\n');
+	let message = '**Weekly Translation Report Ready!** <@&1311284611799846942>';
 
-	let message = `**Weekly Translation Report Ready!** <@&1311284611799846942>\n\nWe have ${
-		Object.keys(toTranslate).length
-	} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`;
+	let embedMessage = `We have ${Object.keys(toTranslate).length} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`;
+
+	const embeds = [
+		{
+			id: 661098315,
+			description: `We have ${Object.keys(toTranslate).length} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`,
+			fields: [],
+			author: {
+				name: 'Translation Report',
+				icon_url:
+					'https://github.com/withstudiocms/studiocms.dev/blob/main/assets/logo-discord.png?raw=true',
+			},
+			title: 'Translation Report',
+		},
+	];
 
 	const suffix =
 		'\n\nSee our [Translation Status page](<https://i18n.docs.studiocms.dev>) for more, including open PRs.';
@@ -59,8 +74,13 @@ async function setDiscordMessage() {
 		const lastNewline = message.lastIndexOf('\n', maxLengthWithoutSuffix);
 		message = message.slice(0, lastNewline);
 	}
+	while (embedMessage.length > maxLengthWithoutSuffix) {
+		const lastNewline = embedMessage.lastIndexOf('\n', maxLengthWithoutSuffix);
+		embedMessage = embedMessage.slice(0, lastNewline);
+	}
 
-	message += suffix;
+	embedMessage += suffix;
 
 	setOutput('DISCORD_MESSAGE', message);
+	setOutput('DISCORD_MESSAGE_EMBEDS', JSON.stringify(embeds));
 }

--- a/scripts/lunaria-report-bot.ts
+++ b/scripts/lunaria-report-bot.ts
@@ -47,23 +47,10 @@ async function setDiscordMessage() {
 			})`;
 		})
 		.join('\n');
-	let message = '**Weekly Translation Report Ready!** <@&1311284611799846942>';
 
-	let embedMessage = `We have ${Object.keys(toTranslate).length} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`;
-
-	const embeds = [
-		{
-			id: 661098315,
-			description: `We have ${Object.keys(toTranslate).length} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`,
-			fields: [],
-			author: {
-				name: 'Translation Report',
-				icon_url:
-					'https://github.com/withstudiocms/studiocms.dev/blob/main/assets/logo-discord.png?raw=true',
-			},
-			title: 'Translation Report',
-		},
-	];
+	let message = `**Weekly Translation Report Ready!** <@&1311284611799846942>\n\nWe have ${
+		Object.keys(toTranslate).length
+	} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`;
 
 	const suffix =
 		'\n\nSee our [Translation Status page](<https://i18n.docs.studiocms.dev>) for more, including open PRs.';
@@ -74,13 +61,8 @@ async function setDiscordMessage() {
 		const lastNewline = message.lastIndexOf('\n', maxLengthWithoutSuffix);
 		message = message.slice(0, lastNewline);
 	}
-	while (embedMessage.length > maxLengthWithoutSuffix) {
-		const lastNewline = embedMessage.lastIndexOf('\n', maxLengthWithoutSuffix);
-		embedMessage = embedMessage.slice(0, lastNewline);
-	}
 
-	embedMessage += suffix;
+	message += suffix;
 
 	setOutput('DISCORD_MESSAGE', message);
-	setOutput('DISCORD_MESSAGE_EMBEDS', JSON.stringify(embeds));
 }

--- a/scripts/lunaria-report-bot.ts
+++ b/scripts/lunaria-report-bot.ts
@@ -46,23 +46,9 @@ async function setDiscordMessage() {
 		})
 		.join('\n');
 
-	let message = '**Weekly Translation Report Ready!** <@&1311284611799846942>';
-
-	let embedMessage = `We have ${Object.keys(toTranslate).length} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`;
-
-	const embeds = [
-		{
-			id: 661098315,
-			description: `We have ${Object.keys(toTranslate).length} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`,
-			fields: [],
-			author: {
-				name: 'Translation Report',
-				icon_url:
-					'https://github.com/withstudiocms/studiocms.dev/blob/main/assets/logo-discord.png?raw=true',
-			},
-			title: 'Translation Report',
-		},
-	];
+	let message = `**Weekly Translation Report Ready!** <@&1311284611799846942>\n\nWe have ${
+		Object.keys(toTranslate).length
+	} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`;
 
 	const suffix =
 		'\n\nSee our [Translation Status page](<https://i18n.docs.studiocms.dev>) for more, including open PRs.';
@@ -73,13 +59,8 @@ async function setDiscordMessage() {
 		const lastNewline = message.lastIndexOf('\n', maxLengthWithoutSuffix);
 		message = message.slice(0, lastNewline);
 	}
-	while (embedMessage.length > maxLengthWithoutSuffix) {
-		const lastNewline = embedMessage.lastIndexOf('\n', maxLengthWithoutSuffix);
-		embedMessage = embedMessage.slice(0, lastNewline);
-	}
 
-	embedMessage += suffix;
+	message += suffix;
 
 	setOutput('DISCORD_MESSAGE', message);
-	setOutput('DISCORD_MESSAGE_EMBEDS', JSON.stringify(embeds));
 }

--- a/scripts/lunaria-report-bot.ts
+++ b/scripts/lunaria-report-bot.ts
@@ -46,7 +46,7 @@ async function setDiscordMessage() {
 		})
 		.join('\n');
 
-	let message = `**Weekly Translation Report Ready!** <@&1311284611799846942>\n\nWe have ${
+	let message = `**The weekly translation report is here!** <@&1311284611799846942>\n\nWe have ${
 		Object.keys(toTranslate).length
 	} pages with major changes since last week. Please help us translate these pages to your language!\n\n${list}`;
 


### PR DESCRIPTION
This pull request includes changes to the Discord message formatting and sending process for the Lunaria CI report. The main changes involve simplifying the code and updating the GitHub Actions workflow to use a different action for sending Discord notifications.

### Improvements to Discord message formatting and sending:

* [`.github/workflows/ci-report-lunaria.yml`](diffhunk://#diff-4830bd446dd98c922b0b0991293fb4627e0f83e96b46f4993a6462623e754ad5L26-R31): Updated the workflow to use `Ilshidur/action-discord@0.3.2` for sending Discord notifications, and removed the previous configuration that used `withstudiocms/automations/.github/workflows/discord-msg.yml@main`.

* [`scripts/lunaria-report-bot.ts`](diffhunk://#diff-f4d9f917d54d1f8aa3a541947b787e3aef46a176f311f6f7e3ebba57c48a8a1fL14-R20): Simplified the `setDiscordMessage` function by removing the filtering of the `status` variable and consolidating the message and embed message into a single message string. [[1]](diffhunk://#diff-f4d9f917d54d1f8aa3a541947b787e3aef46a176f311f6f7e3ebba57c48a8a1fL14-R20) [[2]](diffhunk://#diff-f4d9f917d54d1f8aa3a541947b787e3aef46a176f311f6f7e3ebba57c48a8a1fL49-R53) [[3]](diffhunk://#diff-f4d9f917d54d1f8aa3a541947b787e3aef46a176f311f6f7e3ebba57c48a8a1fL76-L84)