### PR TITLE
Replace Patreon link with Open Collective in astro.config.mts

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -67,7 +67,7 @@ export default defineConfig({
 				youtube: 'https://www.youtube.com/@StudioCMS',
 				'x.com': 'https://x.com/withstudiocms',
 				blueSky: 'https://bsky.app/profile/studiocms.dev',
-				patreon: 'https://patreon.com/StudioCMS',
+				openCollective: 'https://opencollective.com/StudioCMS',
 			},
 			customCss: [
 				'@studiocms/ui/css/global.css',


### PR DESCRIPTION
This pull request includes a change to the `astro.config.mts` file, updating the social media links for StudioCMS. The most important change is the replacement of the Patreon link with an Open Collective link.

* [`astro.config.mts`](diffhunk://#diff-bc698b4a8f26fde0949c1c343625370f7dc59083d78056456f68b5ec2182f820L70-R70): Replaced the `patreon` link with the `openCollective` link in the social media section.