### PR TITLE
i18n(fr): translate remaining `start-here` pages

### DIFF
--- a/src/content/docs/fr/start-here/configuration.mdx
+++ b/src/content/docs/fr/start-here/configuration.mdx
@@ -1,0 +1,87 @@
+---
+i18nReady: true
+title: "Configuration de StudioCMS"
+description: "Options permettant de définir la configuration de StudioCMS"
+sidebar:
+  order: 3
+---
+
+import { FileTree } from "@astrojs/starlight/components";
+import ReadMore from "~/components/ReadMore.astro";
+
+# Options disponibles
+
+Il existe deux manières de configurer l’intégration StudioCMS. Vous trouverez ci-dessous des exemples de configuration selon que vous choisissez d’utiliser le fichier `astro.config.mjs` ou le fichier dédié `studiocms.config.mjs`.
+
+<ReadMore>
+Cette page vous explique comment et où définir la configuration de StudioCMS. Pour plus d’informations sur les options de configuration de StudioCMS, consultez les [pages de référence][reference-page].
+</ReadMore>
+
+## En utilisant le fichier `astro.config.mjs` :
+
+```ts twoslash title="astro.config.mjs"
+import db from "@astrojs/db";
+import node from "@astrojs/node";
+import studioCMS from "studiocms";
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  site: "https://demo.studiocms.dev/",
+  output: "server",
+  adapter: node({ mode: "standalone" }),
+  integrations: [
+    db(),
+    studioCMS({
+      dbStartPage: false,
+      // ...AutresOptionsDeConfig
+    }),
+  ],
+});
+```
+
+## En utilisant le fichier `studiocms.config.mjs` (recommandé) :
+
+Ce fichier sera automatiquement récupéré et écrasera toutes les options transmises dans votre fichier astro.config. Si vous choisissez d’utiliser cette option, assurez-vous de déplacer toutes les options de configuration de StudioCMS dans ce fichier comme ci-dessous :
+
+### Exemple de structure de fichiers
+
+<FileTree>
+
+- .env
+- astro.config.mjs
+- **studiocms.config.mjs**
+- studiocms-auth.config.json Généré automatiquement
+- package.json
+- src
+  - env.d.ts
+  - ...
+
+</FileTree>
+
+### Exemple de configuration
+
+```ts twoslash title="astro.config.mjs"
+import db from "@astrojs/db";
+import node from "@astrojs/node";
+import studioCMS from "studiocms";
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  site: "https://demo.studiocms.dev/",
+  output: "server",
+  adapter: node({ mode: "standalone" }),
+  integrations: [db(), studioCMS()],
+});
+```
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from "studiocms/config";
+
+export default defineStudioCMSConfig({
+  dbStartPage: false,
+  // ...AutresOptionsDeConfig
+});
+```
+
+{/* Links */}
+[reference-page]: /fr/config-reference/options-schema/

--- a/src/content/docs/fr/start-here/environment-variables.mdx
+++ b/src/content/docs/fr/start-here/environment-variables.mdx
@@ -1,0 +1,112 @@
+---
+i18nReady: true
+title: Variables d'environnement
+description: Un bref aperçu des variables d’environnement utilisées dans StudioCMS.
+sidebar:
+   order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import ReadMore from '~/components/ReadMore.astro';
+
+Pour que StudioCMS fonctionne correctement, vous devez configurer les variables d’environnement appropriées. Ces variables sont essentielles pour établir une connexion sécurisée à Astro DB et s’authentifier auprès de l’API StudioCMS. Sans configuration correcte de ces variables d’environnement, l’application ne fonctionnera pas comme prévu.
+
+Vous pouvez créer un fichier `.env` dans le répertoire racine de votre projet et ajouter les variables d’environnement requises. Ce fichier texte contient des paires clé-valeur de variables d’environnement. Ces variables sont lues par l’application lors de l’exécution.
+
+Pour référence future sur la façon de travailler avec les variables d’environnement dans Astro, vous pouvez consulter [Variables d’environnement](https://docs.astro.build/fr/guides/environment-variables/) dans la documentation d’Astro.
+
+## Variables d’environnement requises
+
+Afin d’utiliser StudioCMS, il existe quelques variables d’environnement requises que vous devez configurer dans votre fichier `.env`.
+
+### URL de la base de données et jeton pour `@astrojs/db`
+
+`ASTRO_DB_REMOTE_URL` - L’URL de connexion à votre serveur libSQL
+`ASTRO_DB_APP_TOKEN` - Le jeton d’application pour votre serveur libSQL
+
+```bash title=".env"
+ASTRO_DB_REMOTE_URL=libsql://votre.serveur.io
+ASTRO_DB_APP_TOKEN=eyJh...RUCg
+```
+
+<ReadMore>Pour plus d’informations sur `@astrojs/db`, consultez la [documentation d’Astro pour Astro DB](https://docs.astro.build/fr/guides/astro-db/)</ReadMore>
+
+### Clé de chiffrement pour `@studiocms/auth`
+
+`CMS_ENCRYPTION_KEY` - Une clé de chiffrement sécurisée pour chiffrer les données sensibles
+
+```bash title=".env"
+CMS_ENCRYPTION_KEY="wqR+w...sRcg=="
+```
+
+<Aside type="note" title="Utiliser OpenSSL">
+Vous pouvez générer une clé de chiffrement sécurisée à l’aide de la commande suivante :
+```bash
+openssl rand --base64 16
+``` 
+</Aside>
+
+## Variables d’environnement facultatives
+
+### Variables d’environnement d’authentification oAuth
+
+<ReadMore>
+Pour plus d’informations sur la configuration de l’authentification oAuth, consultez la documentation [Configurer l’authentification oAuth][config-oauth].
+</ReadMore>
+
+#### GitHub (facultatif)
+
+Pour vous authentifier avec GitHub, vous devez ajouter les variables d’environnement suivantes à votre fichier `.env` :
+
+```bash title=".env"
+# identifiants pour GitHub OAuth
+CMS_GITHUB_CLIENT_ID=
+CMS_GITHUB_CLIENT_SECRET=
+CMS_GITHUB_REDIRECT_URI=
+```
+
+<Aside type="note" title="Note">
+`CMS_GITHUB_REDIRECT_URI` est optionnelle si vous utilisez plusieurs URI de redirection avec GitHub oAuth.
+</Aside>
+
+#### Discord (facultatif)
+
+```bash title=".env"
+# identifiants pour Discord OAuth
+CMS_DISCORD_CLIENT_ID=
+CMS_DISCORD_CLIENT_SECRET=
+CMS_DISCORD_REDIRECT_URI=
+```
+
+#### Google (facultatif)
+
+```bash title=".env"
+# identifiants pour Google OAuth
+CMS_GOOGLE_CLIENT_ID=
+CMS_GOOGLE_CLIENT_SECRET=
+CMS_GOOGLE_REDIRECT_URI=
+```
+
+#### Auth0 (facultatif)
+
+```bash title=".env"
+# identifiants pour auth0 OAuth
+CMS_AUTH0_CLIENT_ID=
+CMS_AUTH0_CLIENT_SECRET=
+CMS_AUTH0_DOMAIN=
+CMS_AUTH0_REDIRECT_URI=
+```
+
+### Variables d’environnement du gestionnaire d’images
+
+#### Cloudinary (facultatif)
+
+Si vous choisissez d’utiliser le plugin Cloudinary intégré, vous devrez définir les éléments suivants :
+
+```bash title=".env"
+## SDK Javascript de Cloudinary
+CMS_CLOUDINARY_CLOUDNAME="demo"
+```
+
+{/* Links */}
+[config-oauth]: /fr/start-here/getting-started/#facultatif-configurer-lauthentification-oauth

--- a/src/content/docs/fr/start-here/gallery.mdx
+++ b/src/content/docs/fr/start-here/gallery.mdx
@@ -1,0 +1,15 @@
+---
+i18nReady: true
+title: Galerie
+description: Une petite galerie d’images pour présenter StudioCMS
+tableOfContents: false
+sidebar:
+   order: 5
+---
+
+import Gallery from '~/components/Gallery.astro'
+import { mainDemoGalleryImages } from "~/assets/index.ts"
+
+Il s’agit d’une petite galerie d’images pour présenter l’intégration `StudioCMS`.
+
+<Gallery galleryImages={mainDemoGalleryImages} />

--- a/src/content/docs/fr/start-here/why-studioCMS.mdx
+++ b/src/content/docs/fr/start-here/why-studioCMS.mdx
@@ -1,0 +1,32 @@
+---
+i18nReady: true
+title: Pourquoi StudioCMS ?
+description: StudioCMS est une alternative aux plateformes CMS traditionnelles. Ce CMS headless s’appuie sur Astro DB et Astro pour offrir une expérience de gestion de contenu fluide.
+sidebar:
+  order: 4
+---
+
+Astro est un framework axé sur le contenu. Des fonctionnalités telles que les collections de contenu et la nouvelle couche de contenu simplifient considérablement la gestion de contenu, quelle que soit sa taille ou sa forme.
+
+Cependant, cette solution requiert un niveau de développement suffisant, ou au moins une bonne connaissance de la façon dont Astro utilise les fichiers
+placés dans votre répertoire de contenu. De plus, l’expérience qu’il offre n’est pas quelque chose que vous pouvez présenter à un client ou à toute personne souhaitant uniquement une
+expérience de gestion de contenu simplifiée. Un CMS est nécessaire pour cela.
+
+Il existe de nombreux CMS, avec différentes saveurs et fonctionnalités adaptées à vos besoins, mais aucun n’exploite pleinement toutes les capacités d’Astro.
+C’est pourquoi StudioCMS existe : un CMS entièrement axé sur Astro et capable de s’adapter à chacune de ses fonctionnalités pour fournir une expérience de développement (DX) hautement améliorée.
+
+## Principales fonctionnalités
+
+- **`@astrojs/db` :** Nous utilisons Astro DB, ce qui signifie que vous pouvez choisir où et comment vos données sont stockées, qu’il s’agisse de Turso ou d’un fichier local.
+
+- **Moteur de rendu Markdown personnalisé :** Moteur de rendu Markdown intégré avec prise en charge des apartés thématiques et de styles personnalisables pour répondre à vos besoins.
+
+- **Authentification intégrée :** Système d’authentification complet avec prise en charge intégrée du chiffrement des mots de passe, de la gestion des sessions, de la limitation du débit et des niveaux d’autorisation personnalisables.
+
+- **Importateur WordPress :** Il est facile de passer à StudioCMS à partir de n’importe quelle installation WordPress standard !
+
+- **Système de modules d’extension :** Architecture de modules d’extension extensible qui permet des types de pages personnalisés, des widgets de tableau de bord et des pages de paramètres.
+
+- **Rendu du contenu :** Prise en charge intégrée du rendu de contenu personnalisable avec des fonctionnalités telles que des apartés thématiques et la mise en forme de Markdown.
+
+- **Et ce n’est pas fini :** StudioCMS est en développement actif ! Nous ajouterons progressivement de nouvelles fonctionnalités pour une expérience de contenu encore plus fluide ! N’hésitez pas à [ouvrir un ticket](https://github.com/withstudiocms/studiocms/issues/new/choose) si vous avez des suggestions ou des retours d’expérience !


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Since the remaining `start-here` pages was shorter than `getting-started`, I translated all of them in French at once:
* `start-here/configuration`
* `start-here/environment-variables`
* `start-here/gallery`
* `start-here/why-studioCMS`

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->