### PR TITLE
i18n(fr): add `config-reference/dashboard.mdx`

### DIFF
--- a/src/content/docs/fr/config-reference/dashboard.mdx
+++ b/src/content/docs/fr/config-reference/dashboard.mdx
@@ -1,0 +1,227 @@
+---
+i18nReady: true
+title: Configuration du tableau de bord
+description: Page de référence pour les options de configuration du tableau de bord de StudioCMS
+sidebar:
+  order: 6
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+Référence du schéma des options de configuration de l’intégration StudioCMS
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    dashboardEnabled: true,
+    dashboardRouteOverride: 'dashboard',
+    developerConfig: {},
+    faviconURL: '/favicon.svg',
+    inject404Route: true,
+    versionCheck: true,
+    AuthConfig: {},
+  },
+});
+```
+
+## `dashboardEnabled`
+
+`dashboardEnabled` est un booléen utilisé pour déterminer si le tableau de bord est activé.
+
+- **Type :** `boolean`
+- **Par défaut :** `true`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    dashboardEnabled: true, // PAR DÉFAUT - Ceci active le tableau de bord.
+  }
+})
+```
+
+## `DashboardRouteOverride`
+
+`DashboardRouteOverride` est une chaîne de caractères utilisée pour déterminer la route du tableau de bord.
+
+- **Type :** `string`
+- **Par défaut :** `'dashboard'`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    dashboardRouteOverride: 'dashboard', // PAR DÉFAUT - Ceci définit la route du tableau de bord sur /dashboard.
+  }
+})
+```
+
+## `developerConfig`
+
+`developerConfig` est un objet utilisé pour configurer les paramètres du développeur pour le tableau de bord.
+
+### Utilisation
+
+```ts twoslash {3-5} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    developerConfig: {
+        demoMode: false, // PAR DÉFAUT - Ceci désactive le mode démo.
+    },
+  }
+})
+```
+
+## `faviconURL`
+
+`faviconURL` est une chaîne de caractères utilisée pour déterminer le chemin vers le favicon du tableau de bord.
+
+- **Type :** `string`
+- **Par défaut :** `'/favicon.svg'`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    faviconURL: '/favicon.svg', // PAR DÉFAUT - Ceci définit le favicon du tableau de bord.
+  }
+})
+```
+
+## `inject404Route`
+
+`inject404Route` est un booléen utilisé pour déterminer si la route 404 doit être injectée.
+
+- **Type :** `boolean`
+- **Par défaut :** `true`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    inject404Route: true, // PAR DÉFAUT - Ceci injecte la route 404.
+  }
+})
+```
+
+## `versionCheck`
+
+`versionCheck` est un booléen utilisé pour déterminer si la vérification des versions doit être activée.
+
+- **Type :** `boolean`
+- **Par défaut :** `true`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    versionCheck: true, // PAR DÉFAUT - Ceci active la vérification des versions.
+  }
+})
+```
+
+## `AuthConfig`
+
+`AuthConfig` est un objet utilisé pour configurer les paramètres d’authentification du tableau de bord.
+
+### Utilisation
+
+```ts twoslash {3-5} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    AuthConfig: {
+        enabled: true, // PAR DÉFAUT - Ceci active l’authentification.
+    },
+  }
+})
+```
+
+### `providers`
+
+`providers` est un objet utilisé pour configurer les fournisseurs d’authentification pour le tableau de bord.
+
+- **Type :** [`AuthProviders`](#authprovider)
+- **Par défaut :** `{}`
+
+#### Utilisation
+
+```ts twoslash {4-11} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    AuthConfig: {
+        providers: {
+            google: true,
+            github: true,
+            discord: true,
+            auth0: true,
+            usernameAndPassword: true,
+            usernameAndPasswordConfig: {},
+        },
+    },
+  },
+})
+```
+
+#### `usernameAndPasswordConfig`
+
+`usernameAndPasswordConfig` est un objet utilisé pour configurer les paramètres de nom d’utilisateur et de mot de passe pour le tableau de bord.
+
+- **Type :** `{ allowUserRegistration?: boolean }`
+- **Par défaut :** `{}`
+
+##### Utilisation
+
+```ts twoslash {5-8} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dashboardConfig: {
+    AuthConfig: {
+        providers: {
+            usernameAndPassword: true,
+            usernameAndPasswordConfig: {
+                allowUserRegistration: true, // PAR DÉFAUT - Ceci permet l’enregistrement de l’utilisateur.
+            },
+        },
+    },
+  },
+})
+```
+
+###### `AuthProvider`
+
+```ts
+type AuthProviders: {
+    github?: boolean | undefined;
+    discord?: boolean | undefined;
+    google?: boolean | undefined;
+    auth0?: boolean | undefined;
+    usernameAndPassword?: boolean | undefined;
+    usernameAndPasswordConfig?: {
+        allowUserRegistration?: boolean | undefined;
+    } | undefined;
+} | undefined
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds the French translation of `config-reference/dashboard`.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a comprehensive reference guide covering StudioCMS dashboard configuration options.
  - The guide details various settings including toggling the dashboard, custom routing, developer-specific adjustments, favicon setup, error route injection, version checks, and authentication configurations with usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->