### PR TITLE
i18n(fr): translates remaining files in `config-reference`

### DIFF
--- a/src/content/docs/fr/config-reference/dashboard.mdx
+++ b/src/content/docs/fr/config-reference/dashboard.mdx
@@ -12,7 +12,7 @@ Référence du schéma des options de configuration de l’intégration StudioCM
 
 ```ts twoslash title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     dashboardEnabled: true,
@@ -37,7 +37,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     dashboardEnabled: true, // PAR DÉFAUT - Ceci active le tableau de bord.
@@ -56,7 +56,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     dashboardRouteOverride: 'dashboard', // PAR DÉFAUT - Ceci définit la route du tableau de bord sur /dashboard.
@@ -72,7 +72,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3-5} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     developerConfig: {
@@ -93,7 +93,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     faviconURL: '/favicon.svg', // PAR DÉFAUT - Ceci définit le favicon du tableau de bord.
@@ -112,7 +112,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     inject404Route: true, // PAR DÉFAUT - Ceci injecte la route 404.
@@ -131,7 +131,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     versionCheck: true, // PAR DÉFAUT - Ceci active la vérification des versions.
@@ -147,7 +147,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3-5} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     AuthConfig: {
@@ -168,7 +168,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {4-11} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     AuthConfig: {
@@ -196,7 +196,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {5-8} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dashboardConfig: {
     AuthConfig: {

--- a/src/content/docs/fr/config-reference/default-frontend-config.mdx
+++ b/src/content/docs/fr/config-reference/default-frontend-config.mdx
@@ -12,7 +12,7 @@ Référence du schéma des options de configuration de l’intégration StudioCM
 
 ```ts twoslash title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   defaultFrontEndConfig: {
     favicon: '/favicon.svg',
@@ -34,7 +34,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   defaultFrontEndConfig: {
     favicon: '/favicon.svg', // PAR DÉFAUT - Ceci utilise le favicon par défaut.
@@ -53,7 +53,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   defaultFrontEndConfig: {
     htmlDefaultLanguage: 'en', // PAR DÉFAUT - Ceci utilise la langue par défaut.
@@ -70,7 +70,7 @@ Peut être utile pour ajouter le suivi analytique et d’autres scripts et resso
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   defaultFrontEndConfig: {
     htmlDefaultHead: [
@@ -111,7 +111,7 @@ Injecte une interface utilisateur pour des actions rapides dans le coin inférie
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   defaultFrontEndConfig: {
     injectQuickActionsMenu: true, // PAR DÉFAUT - Ceci injecte le menu d’actions rapides.

--- a/src/content/docs/fr/config-reference/default-frontend-config.mdx
+++ b/src/content/docs/fr/config-reference/default-frontend-config.mdx
@@ -1,0 +1,120 @@
+---
+i18nReady: true
+title: Configuration du front-end par défaut
+description: Page de référence pour les options de configuration du front-end par défaut de StudioCMS
+sidebar:
+  order: 5
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+Référence du schéma des options de configuration de l’intégration StudioCMS
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  defaultFrontEndConfig: {
+    favicon: '/favicon.svg',
+    htmlDefaultLanguage: 'en',
+    htmlDefaultHead: [],
+    injectQuickActionsMenu: true,
+  },
+});
+```
+
+## `favicon`
+
+`favicon` est une chaîne de caractère utilisée pour déterminer le chemin vers le favicon du site.
+
+- **Type :** `string`
+- **Par défaut :** `'/favicon.svg'`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  defaultFrontEndConfig: {
+    favicon: '/favicon.svg', // PAR DÉFAUT - Ceci utilise le favicon par défaut.
+  }
+})
+```
+
+## `htmlDefaultLanguage`
+
+`htmlDefaultLanguage` est une chaîne de caractère utilisée pour déterminer la langue par défaut du site.
+
+- **Type :** `string`
+- **Par défaut :** `'en'`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  defaultFrontEndConfig: {
+    htmlDefaultLanguage: 'en', // PAR DÉFAUT - Ceci utilise la langue par défaut.
+  }
+})
+```
+
+## `htmlDefaultHead`
+
+**Type :** [`HeadConfig[]`](#headconfig)
+
+Ajoutez des balises personnalisées au `<head>` de votre site Starlight.
+Peut être utile pour ajouter le suivi analytique et d’autres scripts et ressources tiers.
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  defaultFrontEndConfig: {
+    htmlDefaultHead: [
+      // Exemple : ajouter une balise de script Fathom Analytics.
+      {
+        tag: 'script',
+        attrs: {
+          src: 'https://cdn.usefathom.com/script.js',
+          'data-site': 'MON-ID-FATHOM',
+          defer: true,
+        },
+      },
+    ],
+  },
+});
+```
+
+Les entrées dans `head` sont converties directement en éléments HTML et ne sont pas affectés par le traitement des [scripts](https://docs.astro.build/fr/guides/client-side-scripts/#traitement-des-scripts) ou des [styles](https://docs.astro.build/fr/guides/styling/#styliser-avec-astro) d’Astro.
+
+#### `HeadConfig`
+
+```ts
+interface HeadConfig {
+	tag: string;
+	attrs?: Record<string, string | boolean | undefined>;
+	content?: string;
+}
+```
+
+## `injectQuickActionsMenu`
+
+**Type :** `boolean`
+**Par défaut :** `true`
+
+Injecte une interface utilisateur pour des actions rapides dans le coin inférieur droit du site principal, permettant aux utilisateurs de naviguer rapidement vers l’interface d’administration de StudioCMS.
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  defaultFrontEndConfig: {
+    injectQuickActionsMenu: true, // PAR DÉFAUT - Ceci injecte le menu d’actions rapides.
+  }
+})
+```

--- a/src/content/docs/fr/config-reference/default-frontend-config.mdx
+++ b/src/content/docs/fr/config-reference/default-frontend-config.mdx
@@ -88,7 +88,7 @@ export default defineStudioCMSConfig({
 });
 ```
 
-Les entrées dans `head` sont converties directement en éléments HTML et ne sont pas affectés par le traitement des [scripts](https://docs.astro.build/fr/guides/client-side-scripts/#traitement-des-scripts) ou des [styles](https://docs.astro.build/fr/guides/styling/#styliser-avec-astro) d’Astro.
+Les entrées dans `head` sont converties directement en éléments HTML et ne sont pas affectés par le traitement des [scripts](https://docs.astro.build/fr/guides/client-side-scripts/#regroupement-de-script) ou des [styles](https://docs.astro.build/fr/guides/styling/#styliser-avec-astro) d’Astro.
 
 #### `HeadConfig`
 

--- a/src/content/docs/fr/config-reference/image-service.mdx
+++ b/src/content/docs/fr/config-reference/image-service.mdx
@@ -1,0 +1,28 @@
+---
+i18nReady: true
+title: Service d'images
+description: Page de référence pour les options du service d’images de StudioCMS
+sidebar:
+  order: 4
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+Référence du schéma des options de configuration de l’intégration StudioCMS
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  imageService: {
+    cdnPlugin: 'cloudinary-js'
+  },
+});
+```
+
+## `cdnPlugin`
+
+`cdnPlugin` est une énumération utilisée pour déterminer quel module d’extension CDN utiliser pour les images, s’il est activé.
+
+- **Type :** `'cloudinary-js'` | `undefined`
+- **Par défaut :** `undefined`

--- a/src/content/docs/fr/config-reference/image-service.mdx
+++ b/src/content/docs/fr/config-reference/image-service.mdx
@@ -12,7 +12,7 @@ Référence du schéma des options de configuration de l’intégration StudioCM
 
 ```ts twoslash title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   imageService: {
     cdnPlugin: 'cloudinary-js'

--- a/src/content/docs/fr/config-reference/included-integrations.mdx
+++ b/src/content/docs/fr/config-reference/included-integrations.mdx
@@ -1,0 +1,56 @@
+---
+i18nReady: true
+title: Intégrations incluses
+description: Page de référence pour les options des intégrations incluses de StudioCMS
+sidebar:
+  order: 7
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+Référence du schéma des options de configuration de l’intégration StudioCMS
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  includedIntegrations: {
+    robotsTXT: true
+  },
+});
+```
+
+## `robotsTXT`
+
+`robotsTXT` est un booléen ou un objet utilisé pour déterminer si le fichier robots.txt est activé.
+
+- **Type :** `boolean` | [`RobotsConfig`](#robotsconfig) | `undefined`
+- **Par défaut :** `true`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  includedIntegrations: {
+    robotsTXT: true, // PAR DÉFAUT - Ceci active le fichier robots.txt.
+  }
+})
+```
+
+##### `RobotsConfig`
+
+```ts
+interface RobotsConfig {
+  host?: boolean | string;
+  sitemap?: boolean | string | string[];
+  policy?: {
+    userAgent?: string;
+    disallow?: string | string[];
+    allow?: string | string[];
+    crawlDelay?: number;
+    cleanParam?: string | string[];
+  }[] | undefined;
+}
+```

--- a/src/content/docs/fr/config-reference/included-integrations.mdx
+++ b/src/content/docs/fr/config-reference/included-integrations.mdx
@@ -12,7 +12,7 @@ Référence du schéma des options de configuration de l’intégration StudioCM
 
 ```ts twoslash title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   includedIntegrations: {
     robotsTXT: true
@@ -31,7 +31,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   includedIntegrations: {
     robotsTXT: true, // PAR DÉFAUT - Ceci active le fichier robots.txt.

--- a/src/content/docs/fr/config-reference/index.mdx
+++ b/src/content/docs/fr/config-reference/index.mdx
@@ -168,7 +168,7 @@ export default defineStudioCMSConfig({
 
 ## `includedIntegrations`
 
-`inclusIntegrations` est un objet utilisé pour configurer quelles intégrations doivent être incluses.
+`includedIntegrations` est un objet utilisé pour configurer quelles intégrations doivent être incluses.
 
 <ReadMore>[Consultez `includedIntegrations` pour les options complètes][included-integrations]</ReadMore>
 

--- a/src/content/docs/fr/config-reference/index.mdx
+++ b/src/content/docs/fr/config-reference/index.mdx
@@ -1,0 +1,187 @@
+---
+i18nReady: true
+title: StudioCMSOptions
+description: Page de référence pour les options de StudioCMS
+sidebar:
+  order: 1
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+Référence du schéma des options de configuration de l’intégration StudioCMS
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+// Valeurs par défaut affichées
+export default defineStudioCMSConfig({
+  dbStartPage: true,
+  dateLocale: 'en-us',
+  verbose: false,
+  plugins: [],
+  componentRegistry: {},
+  overrides: {},
+  imageService: {},
+  defaultFrontEndConfig: {},
+  dashboardConfig: {},
+  includedIntegrations: {},
+  dateTimeFormat: {},
+  sdk: {},
+  pageTypeOptions: {}
+});
+```
+
+## `dbStartPage`
+
+Page d’initialisation du projet - Utilisée lors de la première configuration pour créer votre configuration de base de données.
+
+- **Type :** `boolean`
+- **Par défaut :** `true`
+
+### Utilisation
+
+```ts twoslash {2} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dbStartPage: true, // PAR DÉFAUT - Cela injecte une page de démarrage pour configurer vos données de base de données.
+})
+```
+
+## `dateLocale`
+
+`dateLocale` est une chaîne de caractères utilisée pour déterminer les paramètres régionaux pour le formatage des dates.
+
+- **Type :** `string`
+- **Par défaut :** `'en-us'`
+
+### Utilisation
+
+```ts twoslash {2} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dateLocale: 'en-us', // PAR DÉFAUT - Ceci définit les paramètres régionaux de date pour le formatage des dates.
+})
+```
+
+## `verbose`
+
+`verbose` est un booléen utilisé pour activer ou désactiver la journalisation détaillée.
+
+- **Type :** `boolean`
+- **Par défaut :** `false`
+
+### Utilisation
+
+```ts twoslash {2} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  verbose: false, // PAR DÉFAUT - Ceci désactive la journalisation détaillée.
+})
+```
+
+## `plugins`
+
+`plugins` est un tableau utilisé pour déterminer quels modules d’extension doivent être chargés.
+
+- **Type :** `StudioCMSPlugin[]`
+- **Par défaut :** `[]`
+
+### Utilisation
+
+```ts twoslash {1, 3-5} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+import blog from '@studiocms/blog';
+export default defineStudioCMSConfig({
+  plugins: [
+    blog(),
+  ],
+})
+```
+
+## `componentRegistry`
+
+`componentRegistry` est un objet utilisé pour enregistrer des composants.
+
+- **Type :** `Record<string, string>`
+- **Par défaut :** `{}`
+
+### Utilisation
+
+```ts twoslash {2-4} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  componentRegistry: {
+    'my-component': 'src/components/MyComponent.astro',
+  },
+})
+```
+
+## `dateTimeFormat`
+
+`dateTimeFormat` est un objet utilisé pour configurer le format de date et d'heure.
+
+- **Type :** `Intl.DateTimeFormatOptions`
+- **Par défaut :** `{}`
+
+### Utilisation
+
+```ts twoslash {2-6} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  dateTimeFormat: {
+    year: "numeric",
+    month: "short",
+    day: "numeric"
+  },
+})
+```
+
+## `overrides`
+
+`overrides` est un objet utilisé pour remplacer la configuration par défaut.
+
+<ReadMore>[Consultez `overrides` pour les options complètes][overrides]</ReadMore>
+
+## `imageService`
+
+`imageService` est un objet utilisé pour configurer le service d’images.
+
+<ReadMore>[Consultez `imageService` pour les options complètes][image-service]</ReadMore>
+
+## `defaultFrontEndConfig`
+
+`defaultFrontEndConfig` est un objet utilisé pour configurer le front-end par défaut.
+
+<ReadMore>[Consultez `defaultFrontEndConfig` pour les options complètes][default-frontend-config]</ReadMore>
+
+## `dashboardConfig`
+
+`dashboardConfig` est un objet utilisé pour configurer le tableau de bord.
+
+<ReadMore>[Consultez `dashboardConfig` pour les options complètes][dashboard]</ReadMore>
+
+## `includedIntegrations`
+
+`inclusIntegrations` est un objet utilisé pour configurer quelles intégrations doivent être incluses.
+
+<ReadMore>[Consultez `includedIntegrations` pour les options complètes][included-integrations]</ReadMore>
+
+## `sdk`
+
+`sdk` est un objet utilisé pour configurer le SDK.
+
+<ReadMore>[Consultez `sdk` pour les options complètes][sdk]</ReadMore>
+
+{/* Links */}
+[overrides]: /fr/config-reference/overrides/
+[image-service]: /fr/config-reference/image-service/
+[default-frontend-config]: /fr/config-reference/default-frontend-config/
+[dashboard]: /fr/config-reference/dashboard/
+[included-integrations]: /fr/config-reference/included-integrations/
+[sdk]: /fr/config-reference/sdk/

--- a/src/content/docs/fr/config-reference/index.mdx
+++ b/src/content/docs/fr/config-reference/index.mdx
@@ -12,7 +12,7 @@ Référence du schéma des options de configuration de l’intégration StudioCM
 
 ```ts twoslash title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 // Valeurs par défaut affichées
 export default defineStudioCMSConfig({
   dbStartPage: true,
@@ -42,7 +42,7 @@ Page d’initialisation du projet - Utilisée lors de la première configuration
 
 ```ts twoslash {2} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dbStartPage: true, // PAR DÉFAUT - Cela injecte une page de démarrage pour configurer vos données de base de données.
 })
@@ -59,7 +59,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {2} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dateLocale: 'en-us', // PAR DÉFAUT - Ceci définit les paramètres régionaux de date pour le formatage des dates.
 })
@@ -76,7 +76,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {2} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   verbose: false, // PAR DÉFAUT - Ceci désactive la journalisation détaillée.
 })
@@ -93,7 +93,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {1, 3-5} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 import blog from '@studiocms/blog';
 export default defineStudioCMSConfig({
   plugins: [
@@ -113,7 +113,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {2-4} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   componentRegistry: {
     'my-component': 'src/components/MyComponent.astro',
@@ -132,7 +132,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {2-6} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   dateTimeFormat: {
     year: "numeric",

--- a/src/content/docs/fr/config-reference/overrides.mdx
+++ b/src/content/docs/fr/config-reference/overrides.mdx
@@ -1,0 +1,77 @@
+---
+i18nReady: true
+title: Remplacements
+description: Page de référence pour les options de remplacements de StudioCMS
+sidebar:
+  order: 2
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+Référence du schéma des options de configuration de l’intégration StudioCMS
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  overrides: {
+    CustomImageOverride: 'src/components/CustomImage.astro',
+    FormattedDateOverride: 'src/components/FormattedDate.astro',
+  },
+});
+```
+
+## `CustomImageOverride`
+
+`CustomImageOverride` est une chaîne de caractères utilisée pour déterminer le chemin d’accès au composant d’image personnalisé.
+
+- **Type :** `string`
+- **Par défaut :** `undefined`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  overrides: {
+    CustomImageOverride: 'src/components/CustomImage.astro',
+  },
+})
+```
+
+## `FormattedDateOverride`
+
+`FormattedDateOverride` est une chaîne de caractères utilisée pour déterminer le chemin d’accès au composant de date personnalisé.
+
+- **Type :** `string`
+- **Par défaut :** `undefined`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  overrides: {
+    FormattedDateOverride: 'src/components/FormattedDate.astro',
+  },
+})
+```
+
+### Composant par défaut
+
+```astro title="FormattedDate.astro"
+---
+import config from 'studiocms:config';
+
+interface Props {
+	date: Date;
+}
+
+const datetime = Astro.props.date.toISOString();
+const formattedDate = Astro.props.date.toLocaleDateString(config.dateLocale, config.dateTimeFormat);
+---
+
+<time {datetime}>{formattedDate}</time>
+```

--- a/src/content/docs/fr/config-reference/overrides.mdx
+++ b/src/content/docs/fr/config-reference/overrides.mdx
@@ -12,7 +12,7 @@ Référence du schéma des options de configuration de l’intégration StudioCM
 
 ```ts twoslash title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   overrides: {
     CustomImageOverride: 'src/components/CustomImage.astro',
@@ -32,7 +32,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   overrides: {
     CustomImageOverride: 'src/components/CustomImage.astro',
@@ -51,7 +51,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   overrides: {
     FormattedDateOverride: 'src/components/FormattedDate.astro',

--- a/src/content/docs/fr/config-reference/sdk.mdx
+++ b/src/content/docs/fr/config-reference/sdk.mdx
@@ -12,7 +12,7 @@ Référence du schéma des options de configuration de l’intégration StudioCM
 
 ```ts twoslash title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   sdk: {
     cacheConfig: {},
@@ -31,7 +31,7 @@ export default defineStudioCMSConfig({
 
 ```ts twoslash {3} title="studiocms.config.mjs"
 import { defineStudioCMSConfig } from 'studiocms/config';
-// ---omis---
+// ---cut---
 export default defineStudioCMSConfig({
   sdk: {
     // PAR DÉFAUT - Ceci utilise la configuration de cache par défaut.

--- a/src/content/docs/fr/config-reference/sdk.mdx
+++ b/src/content/docs/fr/config-reference/sdk.mdx
@@ -1,0 +1,43 @@
+---
+i18nReady: true
+title: SDK
+description: Page de référence pour les options du SDK de StudioCMS
+sidebar:
+  order: 8
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+Référence du schéma des options de configuration de l’intégration StudioCMS
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  sdk: {
+    cacheConfig: {},
+  },
+});
+```
+
+## `cacheConfig`
+
+`cacheConfig` est un objet utilisé pour configurer le cache du SDK.
+
+- **Type :** `boolean` | `{ lifetime?: string | undefined; }` | `undefined`
+- **Par défaut :** `{}`
+
+### Utilisation
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---omis---
+export default defineStudioCMSConfig({
+  sdk: {
+    // PAR DÉFAUT - Ceci utilise la configuration de cache par défaut.
+    cacheConfig: {
+        lifetime: '5m',
+    }, 
+  }
+})
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

* Adds the French translation of the remaining files in `config-reference`
* Fixes the code snippets in `config-reference/dashboard`... I thought `--cut--` could be translated but it's actually a special keyword. My bad, I should have checked yesterday!

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated comment markers in dashboard configuration examples for improved clarity.
  - Added new guides detailing default front-end settings, image delivery options, and included integrations.
  - Introduced comprehensive documentation covering overall configuration parameters, configuration overrides for custom components, and SDK cache settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->