### PR TITLE
fix: replace Weblate with Crowdin in `contributing/translations`

### DIFF
--- a/src/content/docs/en/contributing/translations.mdx
+++ b/src/content/docs/en/contributing/translations.mdx
@@ -24,7 +24,7 @@ Visit [our i18n dashboard](https://i18n.studiocms.dev) to help translate StudioC
 If you would prefer to contribute translations directly to the repository, the translations are stored in the [`packages/studiocms/src/lib/i18n/translations`](https://github.com/withstudiocms/studiocms/tree/main/packages/studiocms/src/lib/i18n/translations/) directory. You can find the English translations in the [`en-us.json`](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/translations/en-us.json) file.
 
 <ReadMore>
-StudioCMS uses [Crowding](https://crowdin.com/) for managing translations on top of GitHub. If you are new to Crowdin, you can find the [For Translators guide](https://support.crowdin.com/for-translators/) on their website.
+StudioCMS uses [Crowdin](https://crowdin.com/) for managing translations on top of GitHub. If you are new to Crowdin, you can find the [For Translators guide](https://support.crowdin.com/for-translators/) on their website.
 </ReadMore>
 
 Once the translations have been added, they will be added to the [StudioCMS i18n configuration](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/index.ts#L8) and will be available in the next release.

--- a/src/content/docs/en/contributing/translations.mdx
+++ b/src/content/docs/en/contributing/translations.mdx
@@ -17,14 +17,14 @@ StudioCMS is a global project, and we want to make it accessible to everyone. If
 
 Current translation status:
 
-<img src="https://i18n.studiocms.dev/widget/studiocms/horizontal-auto.svg" alt="Translation status" />
+<img src="https://badges.awesome-crowdin.com/translation-16993424-776180-update.png" alt="Translation status" />
 
 Visit [our i18n dashboard](https://i18n.studiocms.dev) to help translate StudioCMS into your language. If your language is not listed, you can add it within the dashboard.
 
 If you would prefer to contribute translations directly to the repository, the translations are stored in the [`packages/studiocms/src/lib/i18n/translations`](https://github.com/withstudiocms/studiocms/tree/main/packages/studiocms/src/lib/i18n/translations/) directory. You can find the English translations in the [`en-us.json`](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/translations/en-us.json) file.
 
 <ReadMore>
-StudioCMS uses [Weblate](https://weblate.org) for managing translations on top of GitHub. If you are new to Weblate, you can find the [Translating using Weblate Guide](https://docs.weblate.org/en/latest/user/translating.html#) on their website.
+StudioCMS uses [Crowding](https://crowdin.com/) for managing translations on top of GitHub. If you are new to Crowdin, you can find the [For Translators guide](https://support.crowdin.com/for-translators/) on their website.
 </ReadMore>
 
 Once the translations have been added, they will be added to the [StudioCMS i18n configuration](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/index.ts#L8) and will be available in the next release.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Since Crowdin is the new service used to manage translations, I replaced Weblate with Crowdin in `contributing/translations` (status, guide link and Weblate mentions).


<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated translation documentation with a new status image reflecting the current platform.
	- Modified text to reference Crowdin while providing an updated guide link for translators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->