### PR TITLE
i18n(es): translate `studiocms-markdoc`, `studiocms-mdx` , and `rendering.mdx` documentation files

### DIFF
--- a/src/content/docs/es/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
+++ b/src/content/docs/es/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
@@ -1,0 +1,37 @@
+---
+i18nReady: true
+title: "@studiocms/markdoc"
+type: integration
+catalogEntry: studiocms-markdoc
+description: "Integración de MarkDoc para StudioCMS"
+sidebar:
+  badge: 
+    text: 'Plugin'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+# Introducción
+
+Este plugin habilita el soporte de MarkDoc dentro de StudioCMS.
+
+## Instalación
+
+1. Instala el paquete usando el siguiente comando:
+
+   <PackageManagers pkg="@studiocms/markdoc" />
+
+2. Añade `@studiocms/markdoc` a tu archivo de configuración de Astro:
+
+   ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
+   import { defineStudioCMSConfig } from 'studiocms/config';
+   import markdoc from '@studiocms/markdoc';
+
+    export default defineStudioCMSConfig({
+      plugins: [
+        markdoc(),
+      ],
+    });
+   ```

--- a/src/content/docs/es/package-catalog/studiocms-plugins/studiocms-mdx.mdx
+++ b/src/content/docs/es/package-catalog/studiocms-plugins/studiocms-mdx.mdx
@@ -1,0 +1,37 @@
+---
+i18nReady: true
+title: "@studiocms/mdx"
+type: integration
+catalogEntry: studiocms-mdx
+description: "Integración de MDX para StudioCMS"
+sidebar:
+  badge: 
+    text: 'Plugin'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+# Introducción
+
+Este plugin habilita el soporte de MDX dentro de StudioCMS.
+
+## Instalación
+
+1. Instala el paquete usando el siguiente comando:
+
+   <PackageManagers pkg="@studiocms/mdx" />
+
+2. Añade `@studiocms/mdx` a tu archivo de configuración de Astro:
+
+   ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
+   import { defineStudioCMSConfig } from 'studiocms/config';
+   import mdx from '@studiocms/mdx';
+
+    export default defineStudioCMSConfig({
+      plugins: [
+        mdx(),
+      ],
+    });
+   ```

--- a/src/content/docs/es/utils/rendering.mdx
+++ b/src/content/docs/es/utils/rendering.mdx
@@ -1,0 +1,39 @@
+---
+i18nReady: true
+title: "Renderizado de Contenido"
+description: "Opciones para renderizar Contenido"
+sidebar:
+   order: 1
+---
+
+El sistema de renderizado de StudioCMS es dinámico según el tipo de página actual (pageType).
+
+Ejemplo de ruta comodín (catch-all) donde la página actual se obtiene del SDK y los datos de la página se pasan al renderizador. En este caso, estamos utilizando el tipo de página predeterminado `studiocms/markdown` configurado en la configuración de la página, y envolviéndolo en un Layout como lo hacemos con el plugin `@studiocms/blog`. Por ejemplo, un plugin de constructor de páginas (pageBuilder) puede venir sin un diseño estándar, pero en su lugar pretende que diseñes toda la página dentro del constructor, como lo harías en otros sistemas CMS.
+
+```astro title="src/pages/[...slug].astro"
+---
+import { StudioCMSRenderer } from 'studiocms:renderer';
+import studioCMS_SDK from 'studiocms:sdk';
+import Layout from '../layouts/Layout.astro';
+
+let { slug } = Astro.params;
+
+if (!slug) {
+	slug = 'index';
+}
+
+const page = await studioCMS_SDK.GET.databaseEntry.pages.bySlug(slug);
+
+if (!page) {
+	return Astro.redirect('/404');
+}
+
+const { title, description, heroImage } = page;
+---
+
+<Layout title={title} description={description} heroImage={heroImage}>
+	<main>
+		<StudioCMSRenderer data={page} />
+	</main>
+</Layout>
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- What does this PR change? Give us a brief description.
Translates missing files to spanish 🫡

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added new user guides for integrating the Markdoc plugin, featuring clear installation steps and configuration instructions.
	- Introduced detailed documentation for the MDX plugin, including setup guidance and integration tips.
	- Released a comprehensive overview of the content rendering system, explaining how dynamic pages are retrieved and displayed for a smooth end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->