### PR TITLE
i18n(fr): fix links in translated files

### DIFF
--- a/src/content/docs/fr/config-reference/default-frontend-config.mdx
+++ b/src/content/docs/fr/config-reference/default-frontend-config.mdx
@@ -88,7 +88,7 @@ export default defineStudioCMSConfig({
 });
 ```
 
-Les entrées dans `head` sont converties directement en éléments HTML et ne sont pas affectés par le traitement des [scripts](https://docs.astro.build/fr/guides/client-side-scripts/#regroupement-de-script) ou des [styles](https://docs.astro.build/fr/guides/styling/#styliser-avec-astro) d’Astro.
+Les entrées dans `head` sont converties directement en éléments HTML et ne sont pas affectés par le traitement des [scripts](https://docs.astro.build/fr/guides/client-side-scripts/#traitement-des-scripts) ou des [styles](https://docs.astro.build/fr/guides/styling/#styliser-avec-astro) d’Astro.
 
 #### `HeadConfig`
 

--- a/src/content/docs/fr/start-here/getting-started.mdx
+++ b/src/content/docs/fr/start-here/getting-started.mdx
@@ -359,7 +359,7 @@ Apprenez-en plus sur les options de configuration de StudioCMS à l’aide des p
 [package-catalog]: /fr/package-catalog/
 [environment-variables]: /fr/start-here/environment-variables/
 [config-reference]: /fr/config-reference/
-[db-url-token]: /fr/start-here/environment-variables/#database-url-and-token-for-astrojsdb
-[encryption-key]: /fr/start-here/environment-variables/#encryption-key-for-studiocmsauth
-[oauth-environment-variables]: /fr/start-here/environment-variables/#oauth-authentication-environment-variables
+[db-url-token]: /fr/start-here/environment-variables/#url-de-la-base-de-données-et-jeton-pour-astrojsdb
+[encryption-key]: /fr/start-here/environment-variables/#clé-de-chiffrement-pour-studiocmsauth
+[oauth-environment-variables]: /fr/start-here/environment-variables/#variables-denvironnement-dauthentification-oauth
 [auth-config-ref]: /fr/config-reference/dashboard/#authconfig


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Updates links in the French translation:
* A heading id has been updated in Astro Docs (see https://github.com/withastro/docs/pull/11331) so I updated the link referring to it.
* I forgot to update some links relying on ids in `getting-started`

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the description and reference link for script processing.
	- Revised the environment variables section to use localized French URLs for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->