### PR TITLE
i18n(es): small fixes

### DIFF
--- a/src/content/docs/es/contributing/translations.mdx
+++ b/src/content/docs/es/contributing/translations.mdx
@@ -17,7 +17,7 @@ StudioCMS es un proyecto global y queremos hacerlo accesible para todos. Si domi
 
 Estado actual de las traducciones:
 
-<img src="badges.awesome-crowdin.com/translation-16993424-776180-update.png" alt="Estado de las traducciones" />
+<img src="https://badges.awesome-crowdin.com/translation-16993424-776180-update.png" alt="Estado de las traducciones" />
 
 Visita [nuestro panel de i18n](https://i18n.studiocms.dev) para ayudar a traducir StudioCMS a tu idioma. Si tu idioma no está en la lista, puedes agregarlo dentro del panel.
 

--- a/src/content/docs/es/plugins/extended.mdx
+++ b/src/content/docs/es/plugins/extended.mdx
@@ -109,7 +109,7 @@ export function studioCMSPageInjector(options: Options) {
                     html: '<examplegriditem></examplegriditem>',
                     components: {
                         // Inyecta el componente de Astro para reemplazar el elemento personalizado en html plano
-                        examplegriditem: resolve('./dashboard-grid-items/MycomplementoGridItem.astro')
+                        examplegriditem: resolve('./dashboard-grid-items/MyPluginGridItem.astro')
                     }
                 }
             }
@@ -150,7 +150,7 @@ const makeRoute = (slug: string) => {
 
 // 'my-plugin' aquí se usa como identificador para
 // el pageType de la definición del complemento
-const pages = await sdk.GET.packagePages('my-complemento'); 
+const pages = await sdk.GET.packagePages('my-plugin'); 
 
 const { slug } = Astro.params;
 
@@ -192,7 +192,7 @@ import sdk from 'studiocms:sdk';
 
 // 'my-plugin' aqui es usado como el identificador para
 // el pageType de la definición del complemento
-const pages = await sdk.GET.packagePages('my-complemento'); 
+const pages = await sdk.GET.packagePages('my-plugin'); 
 
 // Consigue las últimas 5 páginas actualizadas en los últimos 30 días
 const recentlyUpdatedPages = pages
@@ -227,7 +227,7 @@ Si deseas usar los ayudantes de navegación incorporados de StudioCMS en tu proy
 ---
 import { StudioCMSRoutes } from 'studiocms:lib';
 import studioCMS_SDK from 'studiocms:sdk/cache';
-import { frontendNavigation } from 'studiocms:complemento-helpers';
+import { frontendNavigation } from 'studiocms:plugin-helpers';
 
 // Define las props para el componente de navegación
 interface Props {

--- a/src/content/docs/es/plugins/index.mdx
+++ b/src/content/docs/es/plugins/index.mdx
@@ -291,8 +291,8 @@ export const myPlugin = (options: Options) => definePlugin({
 
 En este ejemplo, definimos un complemento de StudioCMS llamado `My Plugin` que requiere la versión `0.1.0-beta.8` o superior de StudioCMS. El complemento también proporciona una Integración Astro que registra un mensaje en la consola cuando se llama al hook `astro:config:setup`.
 
-<ReadMore>Para más información sobre la creación de plugins, consulta la Guía [Haciendo Plugins Útiles][reference-page]</ReadMore>
+<ReadMore>Para más información sobre la creación de plugins, consulta la Guía [Haciendo Plugins Útiles][extended-plugins]</ReadMore>
 
 {/* Enlaces */}
 
-[reference-page]: /es/plugins/reference/
+[extended-plugins]: /es/plugins/extended/


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

While I was translating in French, I looked at how some sentences was handled in Spanish and notices some issues, so here's the fixes:
* the image src in `contributing/translations` was missing the protocol so the result was a 404
* in `plugins/index` it seems the link wasn't the same as the one in the English version
* in `plugins/extended` it seems there was some inconsistencies between `complemento` and `plugin`. I reverted back to the English version (`my-plugin`) instead of `mi-complemento` because I wasn't sure you wanted to translate the full example (in `definePlugin` you were using `my-plugin`) (cc @dreyfus92).

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated an image URL to ensure reliable, secure loading.
  - Revised plugin references to reflect updated naming conventions and improve consistency.
  - Adjusted navigation links to direct users to enhanced plugin information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->