### PR TITLE
i18n(ko-KR): update `overrides.mdx`

### DIFF
--- a/src/content/docs/ko/config-reference/overrides.mdx
+++ b/src/content/docs/ko/config-reference/overrides.mdx
@@ -1,0 +1,77 @@
+---
+i18nReady: true
+title: 재정의
+description: StudioCMSOptions 재정의 참조 페이지
+sidebar:
+  order: 2
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+StudioCMS 통합 구성 옵션 스키마 참조
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---cut---
+export default defineStudioCMSConfig({
+  overrides: {
+    CustomImageOverride: 'src/components/CustomImage.astro',
+    FormattedDateOverride: 'src/components/FormattedDate.astro',
+  },
+});
+```
+
+## `CustomImageOverride`
+
+`CustomImageOverride`는 사용자 정의 이미지 컴포넌트의 경로를 결정하는 데 사용되는 문자열입니다.
+
+- **타입:** `string`
+- **기본값:** `undefined`
+
+### 사용법
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---cut---
+export default defineStudioCMSConfig({
+  overrides: {
+    CustomImageOverride: 'src/components/CustomImage.astro',
+  },
+})
+```
+
+## `FormattedDateOverride`
+
+`FormattedDateOverride`는 사용자 정의 날짜 컴포넌트의 경로를 결정하는 데 사용되는 문자열입니다.
+
+- **타입:** `string`
+- **기본값:** `undefined`
+
+### 사용법
+
+```ts twoslash {3} title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+// ---cut---
+export default defineStudioCMSConfig({
+  overrides: {
+    FormattedDateOverride: 'src/components/FormattedDate.astro',
+  },
+})
+```
+
+### 기본 컴포넌트
+
+```astro title="FormattedDate.astro"
+---
+import config from 'studiocms:config';
+
+interface Props {
+	date: Date;
+}
+
+const datetime = Astro.props.date.toISOString();
+const formattedDate = Astro.props.date.toLocaleDateString(config.dateLocale, config.dateTimeFormat);
+---
+
+<time {datetime}>{formattedDate}</time>
+```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

update `overrides.mdx` into Korean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Introduced new documentation for configuring integration options.
	- Detailed two new configuration overrides for custom image and date components with usage examples and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->