### PR TITLE
fix: Search modal translations

### DIFF
--- a/src/starlightOverrides/Search.astro
+++ b/src/starlightOverrides/Search.astro
@@ -25,15 +25,16 @@ const docSearchStrings =
 			for (let i = 0; i < segments.length; i++) {
 				const segment = segments[i];
 				if (i < segments.length - 1) {
+          // Build up the tree structure
 					pointer[segment] ??= {};
 					pointer = pointer[segment];
 				} else {
+          // At the final node, set the leaf value.
 					pointer[segment] = val;
 				}
 			}
-
 			return dict;
-			// biome-ignore lint/suspicious/noExplicitAny:
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 		}, {} as any);
 ---
 

--- a/src/starlightOverrides/Search.astro
+++ b/src/starlightOverrides/Search.astro
@@ -35,8 +35,6 @@ const docSearchStrings =
 			return dict;
 			// biome-ignore lint/suspicious/noExplicitAny:
 		}, {} as any);
-
-console.log(docSearchStrings)
 ---
 
 <sl-doc-search data-translations={JSON.stringify(docSearchStrings)}>

--- a/src/starlightOverrides/Search.astro
+++ b/src/starlightOverrides/Search.astro
@@ -25,11 +25,11 @@ const docSearchStrings =
 			for (let i = 0; i < segments.length; i++) {
 				const segment = segments[i];
 				if (i < segments.length - 1) {
-          // Build up the tree structure
+					// Build up the tree structure
 					pointer[segment] ??= {};
 					pointer = pointer[segment];
 				} else {
-          // At the final node, set the leaf value.
+					// At the final node, set the leaf value.
 					pointer[segment] = val;
 				}
 			}

--- a/src/starlightOverrides/Search.astro
+++ b/src/starlightOverrides/Search.astro
@@ -11,22 +11,32 @@ const docSearchStrings =
 		.map(([key, value]) => [key.replace('docsearch.', ''), value])
 		// 4. Convert the long keys to nested objects (e.g. `modal.footer.closeText` => `modal: { footer: { closeText: "..." } }`)
 		.reduce((dict, [key, val]) => {
+			const exceptions = ['button', 'shortcutLabel', 'placeholder'];
 			const segments = key.split('.');
-			let pointer = dict;
+
+			if (exceptions.includes(key)) {
+				// Directly set at root level
+				dict[key] = val;
+				return dict;
+			}
+
+			// Wrap everything else inside `modal`
+			let pointer = (dict.modal ??= {});
 			for (let i = 0; i < segments.length; i++) {
 				const segment = segments[i];
 				if (i < segments.length - 1) {
-					// Build up the tree structure
 					pointer[segment] ??= {};
 					pointer = pointer[segment];
 				} else {
-					// At the final node, set the leaf value.
 					pointer[segment] = val;
 				}
 			}
+
 			return dict;
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			// biome-ignore lint/suspicious/noExplicitAny:
 		}, {} as any);
+
+console.log(docSearchStrings)
 ---
 
 <sl-doc-search data-translations={JSON.stringify(docSearchStrings)}>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

The problem was in the `Search.astro` override, where the dictionary is generated 1:1 like the values from the `en.json` (+ other languages) files, but most of them need to wrapped inside a `modal: {}` object.
- Closes #50

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the handling of specific configuration keys, allowing for direct assignment at the root level for improved clarity and consistency in the interface presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->