### PR TITLE
i18n(ko-KR): create `sdk.mdx`

### DIFF
--- a/src/content/docs/ko/how-it-works/sdk.mdx
+++ b/src/content/docs/ko/how-it-works/sdk.mdx
@@ -1,0 +1,294 @@
+---
+i18nReady: true
+title: "SDK"
+description: "StudioCMS SDK와 사용법에 대해 알아보세요."
+sidebar:
+   order: 3
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+StudioCMS SDK는 프로그래밍 방식으로 StudioCMS와 상호 작용할 수 있게 해주는 강력한 도구입니다. Astro DB를 사용하여 콘텐츠를 관리하고 제공할 수 있는 다양한 함수와 유틸리티를 제공합니다. 또한 StudioCMS 대시보드의 기반을 제공합니다.
+
+## 사용법
+
+StudioCMS SDK는 Astro 프로젝트에서 가상 모듈로 제공됩니다. 다음 구문을 사용하여 가져올 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+// 또는
+import SDKCached from 'studiocms:sdk/cache';
+```
+
+`studioCMSSDK` 객체는 StudioCMS와 상호 작용할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 Astro 프로젝트에서 콘텐츠를 생성, 읽기, 업데이트 및 삭제할 수 있습니다.
+
+`studioCMSSDKCached` 객체는 캐싱 계층을 덧붙여 StudioCMS SDK와 상호 작용할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 Astro 프로젝트에서 콘텐츠를 캐시할 수 있습니다.
+
+## StudioCMS SDK (표준)
+
+### `SDK.AUTH`
+
+`SDK.AUTH` 객체는 Astro 프로젝트에서 인증을 관리할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 사용자를 인증하고, 세션을 관리하는 등의 작업을 수행할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   oAuth,
+   permission,
+   session,
+   user,
+} = SDK.AUTH;
+```
+
+### `SDK.INIT`
+
+`SDK.INIT` 객체는 Astro 프로젝트에서 StudioCMS SDK를 초기화할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 SDK를 설정하고 구성하는 등의 작업을 수행할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   siteConfig,
+   ghostUser,
+} = SDK.INIT;
+```
+
+### `SDK.GET`
+
+`SDK.GET` 객체는 Astro DB에서 콘텐츠를 검색할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 ID, 타입 등으로 콘텐츠를 가져올 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   database,
+   databaseEntry,
+   databaseTable,
+   permissionsLists,
+   packagePages,
+} = SDK.GET;
+```
+
+### `SDK.POST`
+
+`SDK.POST` 객체는 Astro DB에 콘텐츠를 생성할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 타입, ID 등으로 콘텐츠를 생성할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   databaseEntry,
+   databaseEntries,
+} = SDK.POST;
+```
+
+### `SDK.UPDATE`
+
+`SDK.UPDATE` 객체는 Astro DB에서 콘텐츠를 업데이트할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 ID, 타입 등으로 콘텐츠를 업데이트할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   page,
+   pageContent,
+   tags,
+   categories,
+   permissions,
+   siteConfig,
+   folder,
+} = SDK.UPDATE;
+```
+
+### `SDK.DELETE`
+
+`SDK.DELETE` 객체는 Astro DB에서 콘텐츠를 삭제할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 ID, 타입 등으로 콘텐츠를 삭제할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   page,
+   pageContent,
+   pageContentLang,
+   tags,
+   categories,
+   permissions,
+   diffTracking,
+   folder,
+   user,
+} = SDK.DELETE;
+```
+
+### `SDK.db`
+
+`SDK.db` 객체는 Astro DB와 직접 상호 작용할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 데이터베이스를 쿼리하거나, 사용자 정의 쿼리를 실행하는 등의 작업을 수행할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { db } = SDK;
+```
+
+<ReadMore>`db` 사용 방법에 대한 더 자세한 내용은 [Astro DB 가이드](https://docs.astro.build/ko/guides/astro-db/)를 확인하세요.</ReadMore>
+
+
+### `SDK.REST_API`
+
+`SDK.REST_API` 객체는 REST API가 StudioCMS 및 Astro DB와 상호 작용하는 데 사용하는 다양한 함수와 유틸리티를 제공합니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   tokens: {
+      get: getToken,
+      new: newToken,
+      delete: deleteToken,
+      verify: verifyToken,
+   },
+} = SDK.REST_API;
+```
+
+### `SDK.diffTracking`
+
+`SDK.diffTracking` 객체는 Astro DB의 변경 사항을 추적할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 콘텐츠 변경 사항, 사용자 변경 사항 등을 추적할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const { 
+   insert,
+   clear,
+   get,
+   revertToDiff
+} = SDK.diffTracking;
+```
+
+### 유틸리티 함수
+
+StudioCMS SDK는 SDK와 상호 작용하는 데 사용할 수 있는 다양한 유틸리티 함수도 제공합니다. 이러한 함수는 다음과 같습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDK from 'studiocms:sdk';
+
+const {
+	addPageToFolderTree,
+	findNodeById,
+	findNodeByPath,
+	findNodesAlongPath,
+	getFullPath,
+	parseIdNumberArray,
+	parseIdStringArray,
+	generateRandomIDNumber,
+	generateToken,
+	testToken,
+	combineRanks,
+	verifyRank,
+	buildFolderTree,
+	getAvailableFolders,
+	clearUserReferences,
+	collectCategories,
+	collectTags,
+	collectPageData,
+	collectUserData,
+	generateRandomPassword,
+} = SDK;
+```
+
+## StudioCMS SDK (캐시됨)
+
+StudioCMS SDK는 표준 SDK 위에 캐싱 계층을 둔, SDK 기능의 제한된 하위 집합을 포함하는 캐시된 버전의 SDK도 제공합니다. 다음 구문을 사용하여 캐시된 SDK를 가져올 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDKCached from 'studiocms:sdk/cache';
+```
+
+### `SDKCached.GET`
+
+`SDKCached.GET` 객체는 캐싱 계층을 덧붙여 Astro DB에서 콘텐츠를 검색할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 ID, 타입 등으로 콘텐츠를 가져올 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDKCached from 'studiocms:sdk/cache';
+
+const { 
+   page,
+   pages,
+   siteConfig,
+   latestVersion,
+   folderTree,
+   pageFolderTree,
+   folderList,
+   folder,
+} = SDKCached.GET;
+```
+
+### `SDKCached.CLEAR`
+
+`SDKCached.CLEAR` 객체는 캐시된 SDK의 캐시를 지울 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 특정 콘텐츠 타입의 캐시를 지우거나, 특정 콘텐츠 ID의 캐시를 지우는 등의 작업을 수행할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDKCached from 'studiocms:sdk/cache';
+
+const { 
+   page,
+   pages,
+   latestVersion,
+   folderTree,
+   folderList,
+} = SDKCached.CLEAR;
+```
+
+### `SDKCached.UPDATE`
+
+`SDKCached.UPDATE` 객체는 캐싱 계층을 덧붙여 Astro DB에서 콘텐츠를 업데이트할 수 있는 다양한 함수와 유틸리티를 제공합니다. 이 함수들을 사용하여 ID, 타입 등으로 콘텐츠를 업데이트할 수 있습니다.
+
+```ts twoslash
+/// <reference types="studiocms/v/types" />
+// ---cut---
+import SDKCached from 'studiocms:sdk/cache';
+
+const { 
+   page,
+   siteConfig,
+   latestVersion,
+   folderTree,
+   folderList,
+   folder,
+} = SDKCached.UPDATE;
+```
+
+### `SDKCached.db`
+
+표준 SDK의 `db` 객체로 전달됩니다.
+
+<ReadMore>자세한 정보는 [`SDK.db`](#sdkdb)를 확인하세요.</ReadMore>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

create `sdk.mdx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive Korean-language documentation for the StudioCMS SDK, including detailed overviews of its main features, namespaces, and usage examples.
  - Included information on both the standard and cached SDK variants, with code snippets and references for advanced usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->