### PR TITLE
i18n(ko-KR): create `translations.mdx`

### DIFF
--- a/src/content/docs/en/contributing/translations.mdx
+++ b/src/content/docs/en/contributing/translations.mdx
@@ -21,7 +21,7 @@ Current translation status:
 
 Visit [our i18n dashboard](https://i18n.studiocms.dev) to help translate StudioCMS into your language. If your language is not listed, you can add it within the dashboard.
 
-If you would prefer to contribute translations directly to the repository, the translations are stored in the [`packages/studiocms/src/lib/i18n/translations`](https://github.com/withstudiocms/studiocms/tree/main/packages/studiocms/src/lib/i18n/translations/) directory. You can find the English translations in the [`en-us.json`](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/translations/en-us.json) file.
+If you would prefer to contribute translations directly to the repository, the translations are stored in the [`packages/studiocms/src/lib/i18n/translations`](https://github.com/withstudiocms/studiocms/tree/main/packages/studiocms/src/lib/i18n/translations/) directory. You can find the English translations in the [`en.json`](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/translations/en.json) file.
 
 <ReadMore>
 StudioCMS uses [Crowdin](https://crowdin.com/) for managing translations on top of GitHub. If you are new to Crowdin, you can find the [For Translators guide](https://support.crowdin.com/for-translators/) on their website.

--- a/src/content/docs/ko/contributing/translations.mdx
+++ b/src/content/docs/ko/contributing/translations.mdx
@@ -1,0 +1,34 @@
+---
+i18nReady: true
+title: 번역
+description: StudioCMS 번역에 참여하는 방법을 알아보세요.
+sidebar:
+  order: 2
+  badge:
+    text: 출시 예정
+    variant: note
+---
+
+import ReadMore from '~/components/ReadMore.astro';
+
+StudioCMS는 글로벌 프로젝트이며, 우리는 모든 사람이 접근할 수 있도록 만들고 싶습니다. 여러 언어에 능통하시다면, StudioCMS를 여러분의 언어로 번역하는 데 도움을 주실 수 있습니다.
+
+## 대시보드 국제화
+
+현재 번역 상태:
+
+<img src="https://badges.awesome-crowdin.com/translation-16993424-776180-update.png" alt="Translation status" />
+
+StudioCMS를 여러분의 언어로 번역하는 데 도움을 주시려면 [i18n 대시보드](https://i18n.studiocms.dev)를 방문하세요. 여러분의 언어가 목록에 없다면, 대시보드에서 추가할 수 있습니다.
+
+리포지토리에 직접 번역을 기여하고 싶으시다면, 번역 파일은 [`packages/studiocms/src/lib/i18n/translations`](https://github.com/withstudiocms/studiocms/tree/main/packages/studiocms/src/lib/i18n/translations/) 디렉터리에 저장되어 있습니다. 영어 번역은 [`en.json`](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/translations/en.json) 파일에서 찾을 수 있습니다.
+
+<ReadMore>
+StudioCMS는 GitHub를 기반으로 번역 관리를 위해 [Crowdin](https://crowdin.com/)을 사용합니다. Crowdin을 처음 사용하신다면, 해당 웹사이트에서 [번역가 가이드](https://support.crowdin.com/for-translators/)를 찾으실 수 있습니다.
+</ReadMore>
+
+번역이 추가되면, [StudioCMS 국제화 구성](https://github.com/withstudiocms/studiocms/blob/main/packages/studiocms/src/lib/i18n/index.ts#L8)에 반영되어 다음 릴리스에서 사용할 수 있게 됩니다.
+
+## 문서
+
+**곧 제공될 예정입니다!** StudioCMS 문서 번역을 준비 중입니다. 이에 참여하고 싶으시다면, [Discord](https://chat.studiocms.dev)를 통해 저희에게 연락해 주세요.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- create `translations.mdx`
- update English document for fixing the invalid link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the filename reference for the English translation file in the English documentation.
  - Added a new Korean documentation page outlining how to contribute translations to StudioCMS, including guidance on translation processes, status tracking, and links to relevant resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->