### PR TITLE
i18n(ko-KR): update `package-catalog/` and `index.mdx`

### DIFF
--- a/src/content/docs/ko/index.mdx
+++ b/src/content/docs/ko/index.mdx
@@ -28,8 +28,8 @@ import ListCard from '~/components/landing/ListCard.astro';
 import SplitCard from '~/components/landing/SplitCard.astro';
 import { Center } from 'studiocms:ui/components';
 
-<Card title="StudioCMS에 오신 것을 환영합니다." icon='seti:video'>
-  <Youtube id="Ukh3Zb9VjIM"/>
+<Card title="StudioCMS 데모" icon='seti:video'>
+  <video autoplay loop muted playsinline preload="auto" src="https://cdn.studiocms.dev/studiocms-trailer.mp4" />
 </Card>
 
 <CardGrid>

--- a/src/content/docs/ko/package-catalog/index.mdx
+++ b/src/content/docs/ko/package-catalog/index.mdx
@@ -11,6 +11,8 @@ import { Badge } from '@astrojs/starlight/components';
 
 <Badge text="플러그인" variant="tip"/> 라벨이 있는 모든 패키지는 StudioCMS 또는 해당 대시보드의 기능을 확장하는 패키지입니다.
 
+<Badge text="실험적" variant="danger" /> 라벨이 있는 모든 패키지는 아직 개발 초기 단계에 있으며 언제든지 내부 구조에 큰 변화가 있을 수 있습니다. 이 플러그인은 사용 준비가 되었을 수도 있고, 아직 아닐 수도 있습니다.
+
 <Badge text="누구나 사용 가능" variant="caution"/> 라벨이 있는 모든 패키지는 StudioCMS에 의존하지 않는 프로젝트에서도 설치하고 사용할 수 있습니다. 즉, 자체적으로 작동합니다.
 
 ## 패키지 카탈로그

--- a/src/content/docs/ko/package-catalog/studiocms-plugins/studiocms-blog.mdx
+++ b/src/content/docs/ko/package-catalog/studiocms-plugins/studiocms-blog.mdx
@@ -21,9 +21,9 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 1. 다음 명령어를 사용하여 패키지를 설치합니다.
 
-   <PackageManagers pkg="@studiocms/blog" />
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/blog' />
 
-2. Astro 구성 파일에 `@studiocms/blog`를 추가합니다.
+2. 이제 StudioCMS 구성은 `@studiocms/blog`를 포함해야 합니다.
 
    ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';

--- a/src/content/docs/ko/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
+++ b/src/content/docs/ko/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
@@ -21,9 +21,9 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 1. 다음 명령을 사용하여 패키지를 설치합니다.
 
-   <PackageManagers pkg="@studiocms/markdoc" />
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/markdoc' />
 
-2. Astro 구성 파일에 `@studiocms/markdoc`을 추가합니다.
+2. 이제 StudioCMS 구성은 `@studiocms/markdoc`를 포함해야 합니다.
 
    ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';

--- a/src/content/docs/ko/package-catalog/studiocms-plugins/studiocms-mdx.mdx
+++ b/src/content/docs/ko/package-catalog/studiocms-plugins/studiocms-mdx.mdx
@@ -21,9 +21,9 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 1. 다음 명령을 사용하여 패키지를 설치합니다.
 
-   <PackageManagers pkg="@studiocms/mdx" />
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/mdx' />
 
-2. Astro 구성 파일에 `@studiocms/mdx`를 추가합니다.
+2. 이제 StudioCMS 구성은 `@studiocms/mdx`를 포함해야 합니다.
 
    ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new badge description for "실험적" (experimental) packages in the Korean documentation, clarifying their development status.

- **Documentation**
  - Updated the main welcome card on the Korean StudioCMS documentation landing page with a new title and replaced the embedded YouTube video with a native video player.
  - Improved installation instructions for several StudioCMS plugins in the Korean documentation for greater clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->