### PR TITLE
add summary svg for translations of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # StudioCMS Documentation Website
 
 https://docs.studiocms.dev
+
+### Translation progress
+ 
+ <a href="https://i18n.docs.studiocms.dev/">
+   <img alt="Details of each language’s progress translating the StudioCMS Docs" width="600" src="https://i18n.docs.studiocms.dev/summary.svg" />
+ </a>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 https://docs.studiocms.dev
 
-### Translation progress
- 
+## Translation progress
+
+Below is the current translation progress for StudioCMS documentation across all supported languages:
+
  <a href="https://i18n.docs.studiocms.dev/">
    <img alt="Details of each language’s progress translating the StudioCMS Docs" width="600" src="https://i18n.docs.studiocms.dev/summary.svg" />
  </a>

--- a/lunaria/components.ts
+++ b/lunaria/components.ts
@@ -7,7 +7,10 @@ import type {
 } from '@lunariajs/core';
 import { BaseStyles, CustomStyles } from './styles';
 
-export function html(strings: TemplateStringsArray, ...values: (string | string[])[]) {
+export function html(
+	strings: TemplateStringsArray,
+	...values: ((string | number) | (string | number)[])[]
+) {
 	const treatedValues = values.map((value) => (Array.isArray(value) ? value.join('') : value));
 
 	return String.raw({ raw: strings }, ...treatedValues);
@@ -365,3 +368,74 @@ export const TitleParagraph = html`
 		use your help right now.
 	</p>
 `;
+
+/**
+ * Build an SVG file showing a summary of each language’s translation progress.
+ */
+export const SvgSummary = (config: LunariaConfig, status: LunariaStatus): string => {
+	const localeHeight = 56; // Each locale’s summary is 56px high.
+	const svgHeight = localeHeight * Math.ceil(config.locales.length / 2);
+	return html`<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 400 ${svgHeight}"
+		font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'"
+	>
+		${config.locales
+			.map((locale) => SvgLocaleSummary(status, locale))
+			.sort((a, b) => b.progress - a.progress)
+			.map(
+				({ svg }, index) =>
+					html`<g transform="translate(${(index % 2) * 215} ${Math.floor(index / 2) * 56})"
+						>${svg}</g
+					>`
+			)}
+	</svg>`;
+};
+
+function SvgLocaleSummary(
+	status: LunariaStatus,
+	{ label, lang }: Locale
+): { svg: string; progress: number } {
+	const missingFiles = status.filter(
+		(file) =>
+			file.localizations.find((localization) => localization.lang === lang)?.status === 'missing'
+	);
+	const outdatedFiles = status.filter((file) => {
+		const localization = file.localizations.find((localization) => localization.lang === lang);
+		if (!localization || localization.status === 'missing') {
+			return false;
+		}
+		if (file.type === 'dictionary') {
+			return 'missingKeys' in localization ? localization.missingKeys.length > 0 : false;
+		}
+		return (
+			localization.status === 'outdated' ||
+			('missingKeys' in localization && localization.missingKeys.length > 0)
+		);
+	});
+
+	const doneLength = status.length - outdatedFiles.length - missingFiles.length;
+	const barWidth = 184;
+	const doneFraction = doneLength / status.length;
+	const outdatedFraction = outdatedFiles.length / status.length;
+	const doneWidth = (doneFraction * barWidth).toFixed(2);
+	const outdatedWidth = ((outdatedFraction + doneFraction) * barWidth).toFixed(2);
+
+	return {
+		progress: doneFraction,
+		svg: html`<text x="0" y="12" font-size="11" font-weight="600" fill="#999"
+				>${label} (${lang})</text
+			>
+			<text x="0" y="26" font-size="9" fill="#999">
+				${
+					missingFiles.length === 0 && outdatedFiles.length === 0
+						? '100% complete, amazing job! 🎉'
+						: html`${doneLength} done, ${outdatedFiles.length} outdated, ${missingFiles.length}
+						missing`
+				}
+			</text>
+			<rect x="0" y="34" width="${barWidth}" height="8" fill="#999" opacity="0.25"></rect>
+			<rect x="0" y="34" width="${outdatedWidth}" height="8" fill="#fb923c"></rect>
+			<rect x="0" y="34" width="${doneWidth}" height="8" fill="#c084fc"></rect>`,
+	};
+}

--- a/scripts/lunaria.mts
+++ b/scripts/lunaria.mts
@@ -1,11 +1,13 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { createLunaria } from '@lunariajs/core';
-import { Page } from '../lunaria/components.ts';
+import { Page, SvgSummary } from '../lunaria/components.ts';
 
 const lunaria = await createLunaria();
 const status = await lunaria.getFullStatus();
 
 const html = Page(lunaria.config, status, lunaria);
+const svg = SvgSummary(lunaria.config, status);
 
 mkdirSync('dist/lunaria', { recursive: true });
 writeFileSync('dist/lunaria/index.html', html);
+writeFileSync('dist/lunaria/summary.svg', svg);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
- What does this PR change? Give us a brief description.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an SVG visualization summarizing translation progress for each locale, now generated and saved alongside the HTML output.
- **Documentation**
  - Updated the README to include a "Translation progress" section with a link and embedded image showing translation status across languages.
- **Enhancements**
  - Extended template interpolation to support both string and number values for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->