### PR TITLE
i18n(fr): update `package-catalog`

### DIFF
--- a/src/content/docs/fr/package-catalog/index.mdx
+++ b/src/content/docs/fr/package-catalog/index.mdx
@@ -11,6 +11,8 @@ Le catalogue de paquets est une collection de paquets de StudioCMS ou des membre
 
 Tout paquet étiqueté <Badge text="Module d’extension" variant="tip"/> est un paquet qui étend les fonctionnalités de StudioCMS ou de son tableau de bord.
 
+Les modules d’extension peuvent également être étiquetés comme <Badge text="Expérimental" variant="danger" />, ce qui signifie que le module d’extension en est encore aux premiers stades de développement et pourrait faire face à des changements majeurs dans ses composants internes à tout moment. Ce module d’extension peut être ou non prêt à être utilisé.
+
 Tout paquet étiqueté <Badge text="Utilisable publiquement" variant="caution"/> peut être installé et utilisé dans des projets ne s’appuyant pas sur StudioCMS. Ils peuvent fonctionner de manière autonome.
 
 ## Catalogues de paquets

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-blog.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-blog.mdx
@@ -25,7 +25,7 @@ Ce module d’extension active les fonctionnalités du blog StudioCMS ainsi qu�
 
 2. Votre configuration StudioCMS devrait désormais inclure `@studiocms/blog` :
 
-   ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
+   ```ts twoslash title="studiocms.config.mjs" {2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';
    import blog from '@studiocms/blog';
 

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-blog.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-blog.mdx
@@ -21,9 +21,9 @@ Ce module d’extension active les fonctionnalités du blog StudioCMS ainsi qu�
 
 1. Installez le paquet à l’aide de la commande suivante :
 
-   <PackageManagers pkg="@studiocms/blog" />
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/blog' />
 
-2. Ajoutez `@studiocms/blog` à votre fichier de configuration Astro :
+2. Votre configuration StudioCMS devrait désormais inclure `@studiocms/blog` :
 
    ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
@@ -21,9 +21,9 @@ Ce module d’extension active la prise en charge de MarkDoc dans StudioCMS.
 
 1. Installez le paquet à l’aide de la commande suivante :
 
-   <PackageManagers pkg="@studiocms/markdoc" />
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/markdoc' />
 
-2. Ajoutez `@studiocms/markdoc` à votre fichier de configuration Astro :
+2. Votre configuration StudioCMS devrait désormais inclure `@studiocms/markdoc` :
 
    ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
@@ -25,7 +25,7 @@ Ce module d’extension active la prise en charge de MarkDoc dans StudioCMS.
 
 2. Votre configuration StudioCMS devrait désormais inclure `@studiocms/markdoc` :
 
-   ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
+   ```ts twoslash title="studiocms.config.mjs" {2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';
    import markdoc from '@studiocms/markdoc';
 

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-mdx.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-mdx.mdx
@@ -25,7 +25,7 @@ Ce module d’extension active la prise en charge MDX dans StudioCMS.
 
 2. Votre configuration StudioCMS devrait désormais inclure `@studiocms/mdx` :
 
-   ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
+   ```ts twoslash title="studiocms.config.mjs" {2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';
    import mdx from '@studiocms/mdx';
 

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-mdx.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-mdx.mdx
@@ -21,9 +21,9 @@ Ce module d’extension active la prise en charge MDX dans StudioCMS.
 
 1. Installez le paquet à l’aide de la commande suivante :
 
-   <PackageManagers pkg="@studiocms/mdx" />
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/mdx' />
 
-2. Ajoutez `@studiocms/mdx` à votre fichier de configuration Astro :
+2. Votre configuration StudioCMS devrait désormais inclure `@studiocms/mdx` :
 
    ```ts twoslash title="studiocms.config.mjs" ins={2, 6}
    import { defineStudioCMSConfig } from 'studiocms/config';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #73 and #106 to the French translation of `package-catalog` files.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated package catalog documentation to clarify the "Experimental" label for extension modules.
	- Improved installation instructions and configuration wording for `@studiocms/blog`, `@studiocms/markdoc`, and `@studiocms/mdx` packages for better clarity and explicit command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->