### PR TITLE
i18n(fr): translate new `guides` pages

### DIFF
--- a/src/content/docs/fr/guides/database/sqld-server.mdx
+++ b/src/content/docs/fr/guides/database/sqld-server.mdx
@@ -1,0 +1,156 @@
+---
+i18nReady: true
+title: Serveur libSQL auto-hébergé
+description: Hébergez votre propre serveur sqld libSQL avec Docker
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import { PackageManagers } from 'starlight-package-managers'
+import { FileTree, TabItem, Tabs, Steps, Aside } from '@astrojs/starlight/components';
+
+Le projet `sqld` (« démon SQL ») est un mode serveur pour libSQL créé par Turso. Ce guide explique comment configurer `sqld` pour qu’il fonctionne depuis un conteneur Docker pour votre projet StudioCMS.
+
+<ReadMore>Apprenez-en plus sur `sqld` en utilisant leur [Documentation][sql-docs]</ReadMore>
+
+## Prérequis
+
+- [Docker et Docker Compose][docker-docs] (exécuté sur un serveur ou localement)
+- [OpenSSL][openssl-docs] installé
+- CLI de StudioCMS (disponible depuis la racine de votre projet StudioCMS)
+
+La structure finale du fichier ressemblera à ceci si vous effectuez un test local :
+
+<FileTree>
+
+- docker-compose.yml
+- data/
+- keys/
+- mon-projet-studiocms/
+  - astro.config.mjs
+  - studiocms.config.mjs
+  - package.json
+  - src/
+
+</FileTree>
+
+## Générer des clés privées et publiques
+
+Depuis le répertoire `keys`, exécutez la commande suivante pour créer une nouvelle paire de clés Ed25519 encodées en PKCS#8 :
+```bash  
+openssl genpkey -algorithm Ed25519 -out ./libsql.pem  
+```  
+  
+Extrayez ensuite la clé publique avec :
+
+```bash
+openssl pkey -in ./libsql.pem -pubout -out ./libsql.pub
+```
+
+Cela générera une nouvelle paire de clés PKCS#8 qui sera utilisée pour le serveur `sqld`.
+
+## Générez votre jeton JWT
+
+Accédez au répertoire de votre projet StudioCMS et exécutez la commande suivante :
+
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -c "iss=admin" -e 31556926' />
+
+Le résultat est le jeton d'authentification JWT chiffré avec votre clé privée, qui sera utilisé pour l’authentification libSQL. Gardez à l’esprit que le token sera valable 1 an !
+
+### Mettez à jour votre fichier `.env` de StudioCMS avec les éléments suivants :
+
+```sh
+ASTRO_DB_REMOTE_URL=http://localhost:8080 # Cela devrait pointer vers votre serveur Docker/système local
+ASTRO_DB_APP_TOKEN= # collez ici votre jeton d’authentification JWT encodé en base64URL
+```
+
+## Mise en place du conteneur Docker
+
+Créez un nouveau fichier `docker-compose.yml` en dehors du répertoire du projet StudioCMS, pour l’instance libSQL. Vous disposez alors de deux options pour configurer l’authentification libSQL :
+
+- En utilisant le fichier de clé publique lui-même
+- En utilisant le jeton JWT comme variable d’environnement (la même valeur `ASTRO_DB_APP_TOKEN` que celle que vous avez utilisée dans votre fichier `.env`)
+
+<Tabs>
+
+<TabItem label="Fichier de clé publique">
+
+```yml
+services:
+  libsql:
+    image: ghcr.io/tursodatabase/libsql-server:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+      - "5001:5001"
+    environment:
+      - SQLD_NODE=primary
+      - SQLD_AUTH_JWT_KEY_FILE=/home/.ssh/libsql.pub
+    volumes:
+      - ./data/libsql:/var/lib/sqld
+      - ./keys/libsql.pub:/home/.ssh/libsql.pub
+```
+
+</TabItem>
+
+<TabItem label="Jeton JWT">
+
+```yml
+services:
+  libsql:
+    image: ghcr.io/tursodatabase/libsql-server:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+      - "5001:5001"
+    environment:
+      - SQLD_NODE=primary
+      - SQLD_AUTH_JWT_KEY=collez ici votre jeton JWT
+    volumes:
+      - ./data/libsql:/var/lib/sqld
+```
+
+</TabItem>
+
+</Tabs>
+
+<Aside type="note" title="Déploiement sur Coolify ?">
+Utilisateurs [Coolify](https://coolify.io) : Utilisez notre [Gist GitHub](https://gist.github.com/Adammatthiesen/bfe7c78b2e73996fb3ef1b36ed606a57) pour une configuration Docker Compose compatible avec Coolify qui expose libSQL directement via votre domaine sans le suffixe de port `:8080`.
+</Aside>
+
+## Tout démarrer
+
+<Steps>
+
+1. Démarrez le conteneur Docker :
+
+   À partir du répertoire de base (ou du serveur si vous avez suivi cette voie), exécutez la commande suivante pour démarrer le conteneur du serveur libSQL
+
+   ```sh
+   docker compose up -d
+   ```
+
+2. Synchronisez votre schéma de base de données StudioCMS :
+
+   Allez dans le répertoire de votre projet StudioCMS et exécutez la commande suivante :
+
+   <PackageManagers type="exec" args="astro db push --remote" />
+
+3. Suivez la configuration initiale de votre nouvelle base de données.
+
+   - Consultez [Mise en route][getting-started]
+   
+   :::note
+   Si ce n’est pas la première fois que vous configurez un projet StudioCMS, vous devrez peut-être activer l’option `dbStartPage` dans votre fichier `studiocms.config.mjs`
+   :::
+
+</Steps>
+
+## Réflexions finales
+
+Si vous recherchez une option pour auto-héberger votre propre base de données libSQL avec StudioCMS, `sqld` est une option viable et n’est pas très compliqué à mettre en place et à exécuter si vous le faites correctement. Suivre ce guide vous fournit un serveur libSQL sécurisé à utiliser avec votre projet StudioCMS.
+
+{/* Liens */}
+[sql-docs]: https://github.com/tursodatabase/libsql/blob/main/docs/USER_GUIDE.md
+[docker-docs]: https://docs.docker.com/get-started/get-docker/
+[openssl-docs]: https://docs.openssl.org/3.2/man7/ossl-guide-introduction/#getting-and-installing-openssl
+[getting-started]: /fr/start-here/getting-started/#first-time-setup-or-during-updates-if-the-tables-schema-is-updated

--- a/src/content/docs/fr/guides/database/sqld-server.mdx
+++ b/src/content/docs/fr/guides/database/sqld-server.mdx
@@ -153,4 +153,4 @@ Si vous recherchez une option pour auto-héberger votre propre base de données 
 [sql-docs]: https://github.com/tursodatabase/libsql/blob/main/docs/USER_GUIDE.md
 [docker-docs]: https://docs.docker.com/get-started/get-docker/
 [openssl-docs]: https://docs.openssl.org/3.2/man7/ossl-guide-introduction/#getting-and-installing-openssl
-[getting-started]: /fr/start-here/getting-started/#first-time-setup-or-during-updates-if-the-tables-schema-is-updated
+[getting-started]: /fr/start-here/getting-started/#première-configuration-ou-lors-des-mises-à-jour-si-le-schéma-des-tables-est-mis-à-jour

--- a/src/content/docs/fr/guides/index.mdx
+++ b/src/content/docs/fr/guides/index.mdx
@@ -1,0 +1,20 @@
+---
+i18nReady: true
+title: Guides et tutoriels
+description: Guides et tutoriels pour StudioCMS
+---
+
+## Guides pour les contributeurs
+
+- [Bien démarrer](/fr/guides/contributing/getting-started/) - Découvrez les bases pour contribuer à StudioCMS
+- [Contributions au code](/fr/guides/contributing/code-contributions/) - Apprenez à contribuer au code de StudioCMS
+- [Traductions](/fr/guides/contributing/translations/) - Apprenez à contribuer aux traductions de StudioCMS
+
+## Guides de mise à niveau
+
+- [Notes de version](/fr/guides/upgrade/release-notes/) - Notes de version automatisées générées à partir des journaux des modifications de StudioCMS
+- Consultez la barre latérale pour plus d’options pour cette catégorie, telles que les guides de version spécifiques.
+
+## Bases de données
+
+- [Serveur libSQL auto-hébergé](/fr/guides/database/sqld-server/) - Hébergez votre propre serveur sqld libSQL avec Docker

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-16.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-16.mdx
@@ -1,0 +1,35 @@
+---
+i18nReady: true
+title: "Mise à niveau : 0.1.0-beta.16"
+description: Mettre à niveau StudioCMS vers la version bêta 16
+sidebar:
+  label: 0.1.0-beta.16
+  badge:
+    text: NOUVEAU
+    variant: success
+  order: 999999
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import QuickUpdate from '~/components/QuickUpdate.astro'
+
+<QuickUpdate />
+
+## Modifications avec rupture de compatibilité
+
+- Version minimale d’Astro mise à jour vers `Astro v5.7.1`
+- Sécurité des mots de passe mise à jour
+   - Les utilisateurs doivent être informés de la nécessité de mettre à jour leurs mots de passe après la mise à jour. La prise en charge du hachage des mots de passe hérités sera supprimée à l’avenir.
+
+## Nouvelles caractéristiques/fonctionnalités
+
+- Mises à jour/modifications de la CLI
+   - Nouvelle commande : `studiocms add <plugin>` pour ajouter rapidement de nouveaux modules d’extension à votre projet StudioCMS.
+   - Nouvelle commande : `studiocms crypto [command]` pour de nouveaux utilitaires de sécurité.
+   - Nouvelle commande : `studiocms crypto gen-jwt <key-file>` pour générer des jetons JWT à partir de la CLI.
+   - Correctif : la modification des utilisateurs à partir de la CLI est désormais possible grâce au nouveau schéma Drizzle de base de données partielle pour les utilisateurs et les autorisations.
+
+<ReadMore>Pour plus d’informations sur les nouvelles commandes CLI, consultez la documentation de [la CLI][cli-docs]</ReadMore>
+
+{/* Liens */}
+[cli-docs]: /fr/how-it-works/cli/


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Translates in French the new `guides` pages (index, database, upgrade) added in #73

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive French guide on self-hosting a libSQL server with Docker for StudioCMS projects.
  - Introduced a new French documentation index page organizing contributor, upgrade, and database guides.
  - Published a French upgrade guide for StudioCMS version 0.1.0-beta.16, detailing breaking changes, new CLI features, and password security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->