### PR TITLE
i18n(fr): fix a link to the French version of Astro Docs

### DIFF
--- a/src/content/docs/fr/config-reference/default-frontend-config.mdx
+++ b/src/content/docs/fr/config-reference/default-frontend-config.mdx
@@ -88,7 +88,7 @@ export default defineStudioCMSConfig({
 });
 ```
 
-Les entrées dans `head` sont converties directement en éléments HTML et ne sont pas affectés par le traitement des [scripts](https://docs.astro.build/fr/guides/client-side-scripts/#traitement-des-scripts) ou des [styles](https://docs.astro.build/fr/guides/styling/#styliser-avec-astro) d’Astro.
+Les entrées dans `head` sont converties directement en éléments HTML et ne sont pas affectés par le traitement des [scripts](https://docs.astro.build/fr/guides/client-side-scripts/#traitement-des-scripts) ou des [styles](https://docs.astro.build/fr/guides/styling/#mettre-en-forme-avec-astro) d’Astro.
 
 #### `HeadConfig`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Fixes a link in the French translation of `config-reference/default-frontend-config` because the targeted heading has been updated in the French version of Astro Docs (see https://github.com/withastro/docs/pull/11874)

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated French documentation to clarify the description of how styles are processed in the `head` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->