### PR TITLE
i18n(fr): update `upgrade/versions-guides`

### DIFF
--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-21.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-21.mdx
@@ -4,9 +4,6 @@ title: "Mise à niveau : 0.1.0-beta.21"
 description: Mettre à niveau StudioCMS vers la version Beta.21
 sidebar:
   label: 0.1.0-beta.21
-  badge:
-    text: NOUVEAU
-    variant: success
   order: 999994
 ---
 

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-22.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-22.mdx
@@ -1,0 +1,45 @@
+---
+i18nReady: true
+title: "Mise à niveau : 0.1.0-beta.22"
+description: Mettre à niveau StudioCMS vers la version Beta.22
+sidebar:
+  label: 0.1.0-beta.22
+  order: 999993
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import QuickUpdate from '~/components/QuickUpdate.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+<QuickUpdate />
+
+## Modifications avec rupture de compatibilité
+
+- Supprime la prise en charge dépréciée de `@astrojs/web-vitals` au profit du nouveau paquet `@studiocms/web-vitals`. Consultez le [guide Web Vitals][web-vitals-guide] pour plus d'informations.
+- `studiocms:component-proxy` a été remplacé par `studiocms:component-registry`.
+- Ajout du module virtuel `studiocms:component-registry/runtime` qui exporte les types et les aides suivantes, `getRegistryComponents` et `getRendererComponents` utilisés pour obtenir des composants avec des props et le moteur de rendu des composants respectivement.
+- `importComponentKeys` a été transposée mais dépréciée au profit de la nouvelle fonction `getRendererComponents`.
+- Tous les types de pages (`pageTypes`) internes inclus dans la base ont été supprimés, offrant davantage de flexibilité quant au fonctionnement de StudioCMS pour l'utilisateur. Ce changement signifie également que vous devrez installer au moins un module d'extension de rendu pour StudioCMS.
+- Les modules d'extension `@studiocms/html` et `@studiocms/md` ont été introduits pour gérer respectivement la prise en charge de HTML et de MD. Consultez les documentations de [Module d'extension HTML][studiocms-html] et [Module d'extension MD][studiocms-md] pour plus de détails.
+  - Si vous utilisiez les types de page (`pageTypes`) de `studiocms/markdown` ou de `studiocms/html`, vous devrez installer le plugin correspondant et mettre à jour votre configuration en conséquence.
+- Supprime les fonctions SDK dépréciées et refactorise le SDK pour le rendre plus facile à modifier/lire.
+- Supprime les fonctions précédemment dépréciées et l'ancien système de hachage de mot de passe.
+
+## Nouvelles fonctionnalités
+
+- Les types de pages Markdown et HTML ont été modularisés dans des modules d'extension distincts.
+- Ajout d'un nouveau paquet d'utilitaires de configuration pour une meilleure gestion de la configuration.
+- Registre de composants et SDK refactorisés pour une meilleure maintenabilité et une modification plus facile.
+- Points de terminaison OAuth rationalisés pour une meilleure gestion de l'authentification.
+- Nouveau système de registre de composants (`componentRegistry`) pour la gestion des composants définis par l'utilisateur, permettant plus de flexibilité dans la manière dont les composants sont enregistrés et utilisés dans StudioCMS.
+
+## Corrections de bugs
+
+- Ajout de la prise en charge de l'obtention de dossier SDK pour obtenir par nom ou par ID au lieu de simplement par ID, et ajout des commentaires JSDoc aux fonctions manquantes pour le SDK.
+- Correction : Corriger les exportations pour les composants, les mises en page et ajout d'exportation pour les styles
+
+{/* Liens */}
+[config-doc]: /fr/config-reference/
+[web-vitals-guide]: /fr/package-catalog/community-plugins/web-vitals/
+[studiocms-html]: /fr/package-catalog/studiocms-plugins/studiocms-html/
+[studiocms-md]: /fr/package-catalog/studiocms-plugins/studiocms-md/

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-23.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-23.mdx
@@ -18,7 +18,7 @@ import { Aside } from '@astrojs/starlight/components'
 
 ## Modifications avec rupture de compatibilité
 
-- Refonte d'oAuth : les fournisseurs oAuth ont été modularisés en modules d'extension distincts. Cela signifie que vous devrez installer le module d'extension correspondant pour chaque fournisseur oAuth que vous souhaitez utiliser. Les fournisseurs oAuth existants ont été déplacés vers leurs modules d'extension respectifs :
+- Refonte d'OAuth : les fournisseurs OAuth ont été modularisés en modules d'extension distincts. Cela signifie que vous devrez installer le module d'extension correspondant pour chaque fournisseur OAuth que vous souhaitez utiliser. Les fournisseurs OAuth existants ont été déplacés vers leurs modules d'extension respectifs :
   - [`@studiocms/auth0` pour Auth0][auth0-plugin]
   - [`@studiocms/discord` pour Discord][discord-plugin]
   - [`@studiocms/github` pour GitHub][github-plugin]

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-23.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-23.mdx
@@ -1,0 +1,36 @@
+---
+i18nReady: true
+title: "Mise à niveau : 0.1.0-beta.23"
+description: Mettre à niveau StudioCMS vers la version Beta.23
+sidebar:
+  label: 0.1.0-beta.23
+  badge:
+    text: NOUVEAU
+    variant: success
+  order: 999992
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import QuickUpdate from '~/components/QuickUpdate.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+<QuickUpdate />
+
+## Modifications avec rupture de compatibilité
+
+- Refonte d'oAuth : les fournisseurs oAuth ont été modularisés en modules d'extension distincts. Cela signifie que vous devrez installer le module d'extension correspondant pour chaque fournisseur oAuth que vous souhaitez utiliser. Les fournisseurs oAuth existants ont été déplacés vers leurs modules d'extension respectifs :
+  - [`@studiocms/auth0` pour Auth0][auth0-plugin]
+  - [`@studiocms/discord` pour Discord][discord-plugin]
+  - [`@studiocms/github` pour GitHub][github-plugin]
+  - [`@studiocms/google` pour Google][google-plugin]
+
+## Corrections de bugs
+
+- Correction du SDK : correction d'un problème où `CMSSiteConfigId` n'est pas défini lors de l'initialisation.
+- Correction du widget UserQuickTools : ajuste le widget et le point de terminaison des outils rapides de l'utilisateur pour éviter une erreur 400 réelle dans le navigateur de l'utilisateur
+
+{/* Liens */}
+[auth0-plugin]: /fr/package-catalog/studiocms-plugins/studiocms-auth0/
+[discord-plugin]: /fr/package-catalog/studiocms-plugins/studiocms-discord/
+[github-plugin]: /fr/package-catalog/studiocms-plugins/studiocms-github/
+[google-plugin]: /fr/package-catalog/studiocms-plugins/studiocms-google/


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #150 and #151 to the French translations of `upgrade/versions-guides`:
* translate in French `0-1-0-beta-22.mdx` and `0-1-0-beta-23.mdx`
* remove badge in `0-1-0-beta-21.mdx`

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added French upgrade guides for StudioCMS versions 0.1.0-beta.22 and 0.1.0-beta.23, detailing breaking changes, new features, and bug fixes.
  * Updated documentation to reflect modularization of OAuth providers and enhancements in SDK and extension modules.
  * Removed "NOUVEAU" badge from the 0.1.0-beta-21 upgrade guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->