### PR TITLE
i18n(fr): update `start-here`

### DIFF
--- a/src/content/docs/fr/start-here/configuration.mdx
+++ b/src/content/docs/fr/start-here/configuration.mdx
@@ -4,9 +4,6 @@ title: "Configuration de StudioCMS"
 description: "Options permettant de définir la configuration de StudioCMS"
 sidebar:
    order: 3
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 import { FileTree, Aside } from '@astrojs/starlight/components';

--- a/src/content/docs/fr/start-here/environment-variables.mdx
+++ b/src/content/docs/fr/start-here/environment-variables.mdx
@@ -4,9 +4,6 @@ title: Variables d'environnement
 description: Un bref aperçu des variables d’environnement utilisées dans StudioCMS.
 sidebar:
    order: 2
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -48,57 +45,3 @@ Vous pouvez générer une clé de chiffrement sécurisée à l’aide de la comm
 openssl rand --base64 16
 ``` 
 </Aside>
-
-## Variables d’environnement facultatives
-
-### Variables d’environnement d’authentification oAuth
-
-<ReadMore>
-Pour plus d’informations sur la configuration de l’authentification oAuth, consultez la documentation [Configurer l’authentification oAuth][config-oauth].
-</ReadMore>
-
-#### GitHub (facultatif)
-
-Pour vous authentifier avec GitHub, vous devez ajouter les variables d’environnement suivantes à votre fichier `.env` :
-
-```bash title=".env"
-# identifiants pour GitHub OAuth
-CMS_GITHUB_CLIENT_ID=
-CMS_GITHUB_CLIENT_SECRET=
-CMS_GITHUB_REDIRECT_URI=
-```
-
-<Aside type="note" title="Note">
-`CMS_GITHUB_REDIRECT_URI` est optionnelle si vous utilisez plusieurs URI de redirection avec GitHub oAuth.
-</Aside>
-
-#### Discord (facultatif)
-
-```bash title=".env"
-# identifiants pour Discord OAuth
-CMS_DISCORD_CLIENT_ID=
-CMS_DISCORD_CLIENT_SECRET=
-CMS_DISCORD_REDIRECT_URI=
-```
-
-#### Google (facultatif)
-
-```bash title=".env"
-# identifiants pour Google OAuth
-CMS_GOOGLE_CLIENT_ID=
-CMS_GOOGLE_CLIENT_SECRET=
-CMS_GOOGLE_REDIRECT_URI=
-```
-
-#### Auth0 (facultatif)
-
-```bash title=".env"
-# identifiants pour auth0 OAuth
-CMS_AUTH0_CLIENT_ID=
-CMS_AUTH0_CLIENT_SECRET=
-CMS_AUTH0_DOMAIN=
-CMS_AUTH0_REDIRECT_URI=
-```
-
-{/* Liens */}
-[config-oauth]: /fr/start-here/getting-started/#facultatif-configurer-lauthentification-oauth

--- a/src/content/docs/fr/start-here/getting-started.mdx
+++ b/src/content/docs/fr/start-here/getting-started.mdx
@@ -4,11 +4,14 @@ title: Mise en route
 description: Soyez prêt à construire avec StudioCMS.
 sidebar:
    order: 1
+   badge:
+     text: Mis à jour
+     variant: success
 ---
 
 import { PackageManagers } from 'starlight-package-managers'
 import TursoCLI from '~/components/TursoCLI.astro';
-import { Aside, Steps, Tabs, TabItem, LinkCard } from '@astrojs/starlight/components';
+import { Aside, Steps, Tabs, TabItem, LinkCard, Badge } from '@astrojs/starlight/components';
 import ReadMore from '~/components/ReadMore.astro';
 import { sponsors, SponsorLink } from '~/share-link'
 
@@ -216,6 +219,33 @@ Veuillez noter que l’option `site` dans le fichier `astro.config.mjs` est requ
 StudioCMS nécessite un [adaptateur Astro](https://docs.astro.build/fr/guides/on-demand-rendering/#adaptateurs-de-serveur) pour fonctionner correctement. Assurez-vous de définir un adaptateur prenant en charge les routes SSR dans votre fichier `astro.config.mjs`.
 </Aside>
 
+## Configurer le rendu de StudioCMS <Badge text='Ajouté dans la beta.22' variant='success' />
+
+StudioCMS nécessite qu’au moins l’un des modules d’extension de rendu suivants soit installé et configuré dans votre projet StudioCMS :
+
+- `@studiocms/html` - pour le rendu HTML
+- `@studiocms/md` - pour le rendu Markdown
+- `@studiocms/mdx` - pour le rendu MDX
+- `@studiocms/markdoc` - pour le rendu MarkDoc
+- Ou tout autre module d’extension communautaire prenant en charge le rendu de contenu dans StudioCMS.
+
+N’importe lequel de ces modules d’extension peut être utilisé pour afficher du contenu dans StudioCMS. Vous pouvez utiliser un ou plusieurs de ces modules d’extension dans votre projet, selon vos besoins. Ils peuvent être installés et configurés via le fichier de configuration de StudioCMS ou celui d’Astro.
+
+```ts twoslash title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+import html from '@studiocms/html';
+import md from '@studiocms/md';
+
+export default defineStudioCMSConfig({
+    plugins: [
+        html(),
+        md(),
+    ],
+});
+```
+
+<ReadMore>Pour plus d’informations sur les modules d’extension de rendu disponibles, consultez le [catalogue des paquets][package-catalog]</ReadMore>
+
 ## Configurer l’authentification
 
 StudioCMS Auth nécessite au moins que la [clé de chiffrement][encryption-key] soit définie dans votre fichier `.env`.
@@ -239,9 +269,11 @@ Et utiliser la sortie comme valeur pour `CMS_ENCRYPTION_KEY`.
 Pour plus d’informations sur toutes les variables d’environnement d’authentification disponibles, consultez la page [Variables d’environnement][environment-variables].
 </ReadMore>
 
-### Facultatif : configurer l’authentification oAuth
+### Facultatif : configurer l’authentification oAuth <Badge text='Révisé dans la bêta.23' variant='caution' />
 
-StudioCMS prend en charge l’authentification oAuth avec GitHub, Discord, Google et Auth0. Pour configurer l’authentification oAuth, vous devez définir les [variables d’environnement requises dans votre fichier `.env`][oauth-environment-variables] et vous assurer que le fournisseur est [activé dans votre configuration][auth-config-ref].
+StudioCMS prend en charge divers fournisseurs d’authentification oAuth, en utilisant notre système de modules d’extension pour activer les fournisseurs que vous souhaitez utiliser. Pour commencer, vous devrez trouver un module d’extension pour le fournisseur que vous souhaitez utiliser ou créer votre propre module d’extension.
+
+<ReadMore>Pour plus d’informations sur les modules d’extension d’authentification oAuth disponibles, consultez le [catalogue des paquets][package-catalog]</ReadMore>
 
 Pour configurer les fournisseurs oAuth, une URL de rappel est nécessaire. Cette URL correspond au chemin vers lequel le fournisseur redirigera l’utilisateur après l’authentification.
 
@@ -363,6 +395,5 @@ Apprenez-en plus sur les options de configuration de StudioCMS à l’aide des p
 [config-reference]: /fr/config-reference/
 [db-url-token]: /fr/start-here/environment-variables/#url-de-la-base-de-données-et-jeton-pour-astrojsdb
 [encryption-key]: /fr/start-here/environment-variables/#clé-de-chiffrement-pour-studiocmsauth
-[oauth-environment-variables]: /fr/start-here/environment-variables/#variables-denvironnement-dauthentification-oauth
 [auth-config-ref]: /fr/config-reference/features/#authconfig
 [self-hosted-libsql]: /fr/guides/database/sqld-server/


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #150 and #151 to the French translations in `start-here`.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the French "Getting Started" guide with a new section on configuring rendering plugins, including sample configuration and links to the package catalog.
  * Revised the OAuth authentication section to clarify provider support via extension modules, added callback URL details, and marked the section with a revision badge.
  * Removed detailed OAuth environment variable instructions and badge metadata from related documentation pages for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->