### PR TITLE
i18n(fr): update `package-catalog`

### DIFF
--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-auth0.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-auth0.mdx
@@ -1,0 +1,39 @@
+---
+i18nReady: true
+title: "@studiocms/auth0"
+type: integration
+catalogEntry: studiocms-auth0
+description: "Intégration Auth0 de StudioCMS"
+sidebar:
+  badge: 
+    text: 'Module d’extension'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+
+Ce module d’extension intègre Auth0 en tant que fournisseur OAuth pour StudioCMS, permettant l’authentification via Auth0. Il définit la configuration nécessaire, y compris les variables d’environnement requises et les chemins d’accès aux points de terminaison.
+
+## Utilisation
+
+Ajoutez ce module d’extension dans votre configuration de StudioCMS. (`studiocms.config.mjs`)
+
+```ts title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+import auth0 from '@studiocms/auth0';
+
+export default defineStudioCMSConfig({
+    // autres options ici
+    plugins: [auth0()]
+});
+```
+
+## Variables d’environnement requises
+
+```sh title=".env"
+CMS_AUTH0_CLIENT_ID=<id-de-votre-client>
+CMS_AUTH0_CLIENT_SECRET=<secret-de-votre-client>
+CMS_AUTH0_DOMAIN=<votre-domaine>
+CMS_AUTH0_REDIRECT_URI=<votre-uri-de-redirection>
+```

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-blog.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-blog.mdx
@@ -11,9 +11,13 @@ sidebar:
 ---
 
 import { PackageManagers } from 'starlight-package-managers'
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
 Ce module d’extension active les fonctionnalités du blog StudioCMS ainsi qu’un front-end dans votre projet Astro. Il vous permettra de créer, modifier et supprimer des articles de blog depuis le tableau de bord de StudioCMS.
+
+<Aside>
+Ce module d’extension nécessite le module d’extension `@studiocms/md`.
+</Aside>
 
 ### Que fait ce module d'extension ?
 

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-discord.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-discord.mdx
@@ -1,0 +1,38 @@
+---
+i18nReady: true
+title: "@studiocms/discord"
+type: integration
+catalogEntry: studiocms-discord
+description: "Intégration Discord de StudioCMS"
+sidebar:
+  badge: 
+    text: 'Module d’extension'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+
+Ce module d’extension intègre Discord en tant que fournisseur d’authentification OAuth pour StudioCMS. Il définit la configuration nécessaire, y compris les variables d’environnement requises et les points de terminaison OAuth.
+
+## Utilisation
+
+Ajoutez ce module d’extension dans votre configuration de StudioCMS. (`studiocms.config.mjs`)
+
+```ts title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+import discord from '@studiocms/discord';
+
+export default defineStudioCMSConfig({
+    // autres options ici
+    plugins: [discord()]
+});
+```
+
+## Variables d’environnement requises
+
+```sh title=".env"
+CMS_DISCORD_CLIENT_ID=<id-de-votre-client>
+CMS_DISCORD_CLIENT_SECRET=<secret-de-votre-client>
+CMS_DISCORD_REDIRECT_URI=<votre-uri-de-redirection>
+```

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-github.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-github.mdx
@@ -1,0 +1,38 @@
+---
+i18nReady: true
+title: "@studiocms/github"
+type: integration
+catalogEntry: studiocms-github
+description: "Intégration GitHub de StudioCMS"
+sidebar:
+  badge: 
+    text: 'Module d’extension'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+
+Ce module d’extension intègre GitHub en tant que fournisseur d’authentification OAuth pour StudioCMS. Il configure le service d’authentification nécessaire, y compris le nom du fournisseur, les chemins d’accès aux points de terminaison et les variables d’environnement requises.
+
+## Utilisation
+
+Ajoutez ce module d’extension dans votre configuration de StudioCMS. (`studiocms.config.mjs`)
+
+```ts title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+import github from '@studiocms/github';
+
+export default defineStudioCMSConfig({
+    // autres options ici
+    plugins: [github()]
+});
+```
+
+## Variables d’environnement requises
+
+```sh title=".env"
+CMS_GITHUB_CLIENT_ID=<id-de-votre-client>
+CMS_GITHUB_CLIENT_SECRET=<secret-de-votre-client>
+CMS_GITHUB_REDIRECT_URI=<votre-uri-de-redirection>
+```

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-google.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-google.mdx
@@ -1,0 +1,38 @@
+---
+i18nReady: true
+title: "@studiocms/google"
+type: integration
+catalogEntry: studiocms-google
+description: "Intégration Google de StudioCMS"
+sidebar:
+  badge: 
+    text: 'Module d’extension'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+
+Ce module d’extension intègre l’authentification OAuth de Google à StudioCMS. Il définit la configuration nécessaire, y compris les variables d’environnement requises, les détails du fournisseur OAuth et les chemins d’accès aux points de terminaison pour l’authentification.
+
+## Utilisation
+
+Ajoutez ce module d’extension dans votre configuration de StudioCMS. (`studiocms.config.mjs`)
+
+```ts title="studiocms.config.mjs"
+import { defineStudioCMSConfig } from 'studiocms/config';
+import google from '@studiocms/google';
+
+export default defineStudioCMSConfig({
+    // autres options ici
+    plugins: [google()]
+});
+```
+
+## Variables d’environnement requises
+
+```sh title=".env"
+CMS_GOOGLE_CLIENT_ID=<id-de-votre-client>
+CMS_GOOGLE_CLIENT_SECRET=<secret-de-votre-client>
+CMS_GOOGLE_REDIRECT_URI=<votre-uri-de-redirection>
+```

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-html.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-html.mdx
@@ -1,0 +1,54 @@
+---
+i18nReady: true
+title: "@studiocms/html"
+type: integration
+catalogEntry: studiocms-html
+description: "Intégration HTML de StudioCMS"
+sidebar:
+  badge: 
+    text: 'Module d’extension'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+# Présentation
+
+Ce module d’extension active la prise en charge de HTML dans StudioCMS.
+
+## Installation
+
+1. Installez le paquet à l’aide de la commande suivante :
+
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/html' />
+
+2. Votre configuration StudioCMS devrait maintenant inclure `@studiocms/html` :
+
+   ```ts twoslash title="studiocms.config.mjs" {2, 6}
+   import { defineStudioCMSConfig } from 'studiocms/config';
+   import html from '@studiocms/html';
+
+    export default defineStudioCMSConfig({
+      plugins: [
+        html(),
+      ],
+    });
+   ```
+
+## Options
+
+```ts twoslash
+type htmlOptions = {
+  sanitize: {
+    allowAttributes: Record<string, string[]>;
+    allowComments: boolean;
+    allowComponents: boolean;
+    allowCustomElements: boolean;
+    allowElements: string[];
+    blockElements: string[];
+    dropAttributes: Record<string, string[]>;
+    dropElements: string[];
+  };
+};
+```

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-markdoc.mdx
@@ -11,11 +11,15 @@ sidebar:
 ---
 
 import { PackageManagers } from 'starlight-package-managers'
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
 # Présentation
 
 Ce module d’extension active la prise en charge de MarkDoc dans StudioCMS.
+
+<Aside>
+Ce module d’extension nécessite le module d’extension `@studiocms/md`.
+</Aside>
 
 ## Installation
 

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-md.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-md.mdx
@@ -1,0 +1,78 @@
+---
+i18nReady: true
+title: "@studiocms/md"
+type: integration
+catalogEntry: studiocms-md
+description: "Intégration MD de StudioCMS"
+sidebar:
+  badge: 
+    text: 'Module d’extension'
+    variant: 'tip'
+---
+
+import { PackageManagers } from 'starlight-package-managers'
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+# Présentation
+
+Ce module d’extension active la prise en charge de MD dans StudioCMS.
+
+## Installation
+
+1. Installez le paquet à l’aide de la commande suivante :
+
+   <PackageManagers pkg="studiocms" type='run' args='add @studiocms/md' />
+
+2. Votre configuration StudioCMS devrait maintenant inclure `@studiocms/md` :
+
+   ```ts twoslash title="studiocms.config.mjs" {2, 6}
+   import { defineStudioCMSConfig } from 'studiocms/config';
+   import md from '@studiocms/md';
+
+    export default defineStudioCMSConfig({
+      plugins: [
+        md(),
+      ],
+    });
+   ```
+
+## Options
+
+### Markdown version `studiocms`
+
+```ts twoslash
+type StudioCMSMarkdown = {
+  flavor: "studiocms";
+  autoLinkHeadings: boolean;
+  callouts: false | "github" | "obsidian" | "vitepress";
+  discordSubtext: boolean;
+  sanitize: {
+    allowAttributes: Record<string, string[]>;
+    allowComments: boolean;
+    allowComponents: boolean;
+    allowCustomElements: boolean;
+    allowElements: string[];
+    blockElements: string[];
+    dropAttributes: Record<string, string[]>;
+    dropElements: string[];
+  };
+};
+```
+
+### Markdown version `astro`
+
+```ts twoslash
+type AstroMarkdown = {
+  flavor: "astro";
+  sanitize: {
+    allowAttributes: Record<string, string[]>;
+    allowComments: boolean;
+    allowComponents: boolean;
+    allowCustomElements: boolean;
+    allowElements: string[];
+    blockElements: string[];
+    dropAttributes: Record<string, string[]>;
+    dropElements: string[];
+  };
+};
+```

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-mdx.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-mdx.mdx
@@ -11,11 +11,15 @@ sidebar:
 ---
 
 import { PackageManagers } from 'starlight-package-managers'
-import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
 # Présentation
 
 Ce module d’extension active la prise en charge MDX dans StudioCMS.
+
+<Aside>
+Ce module d’extension nécessite le module d’extension `@studiocms/md`.
+</Aside>
 
 ## Installation
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #150 and #151 to the French translations of `packages-catalog`:
* update `studiocms-blog.mdx`, `studiocms-markdoc.mdx` and `studiocms-mdx.mdx`
* translate `studiocms-auth0.mdx`, `studiocms-discord.mdx`, `studiocms-github.mdx`, `studiocms-google.mdx`, `studiocms-html.mdx` and `studiocms-md.mdx`

I know this looks like a lot but most are short and very similar so I think they will be quick to review. 😅 But if you prefer, I can split next time!

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new French documentation for StudioCMS plugins: Auth0, Discord, GitHub, Google, HTML, and Markdown support modules, including setup instructions and required environment variables.
  * Updated documentation for Blog, Markdoc, and MDX plugins to include notes about required dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->