### PR TITLE
i18n(fr): update files for beta 24

### DIFF
--- a/src/content/docs/fr/config-reference/features.mdx
+++ b/src/content/docs/fr/config-reference/features.mdx
@@ -4,9 +4,6 @@ title: Fonctionnalités
 description: Page de référence pour les fonctionnalités de StudioCMS
 sidebar:
   order: 3
-  badge:
-    text: Mis à jour
-    variant: success
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 5

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-23.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-23.mdx
@@ -4,9 +4,6 @@ title: "Mise à niveau : 0.1.0-beta.23"
 description: Mettre à niveau StudioCMS vers la version Beta.23
 sidebar:
   label: 0.1.0-beta.23
-  badge:
-    text: NOUVEAU
-    variant: success
   order: 999992
 ---
 

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-24.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-24.mdx
@@ -1,0 +1,33 @@
+---
+i18nReady: true
+title: "Mise à niveau : 0.1.0-beta.24"
+description: Mettre à niveau StudioCMS vers la version Beta.24
+sidebar:
+  label: 0.1.0-beta.24
+  badge:
+    text: NOUVEAU
+    variant: success
+  order: 999991
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import QuickUpdate from '~/components/QuickUpdate.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+<QuickUpdate />
+
+## Modifications avec rupture de compatibilité
+
+- Ajout d’une nouvelle table `StudioCMSPluginData` dans AstroDB pour une utilisation par les modules d’extension de StudioCMS, ainsi que de nouveaux utilitaires de SDK pour les modules d’extension permettant de définir les types des tables dynamiquement.
+
+<Aside>
+Lors de la mise à jour, assurez-vous d’exécuter `astro db push --remote` avec votre gestionnaire de paquets pour mettre à jour votre schéma de table **avant d’exécuter la nouvelle version** !
+</Aside>
+
+## Corrections de bugs
+
+- Exportation ajoutée pour `component-registry/types`.
+- Widget `user-quick-tools` optimisé.
+- Introduction d’un nouveau module middleware dans le SDK pour garantir que les objets de cache sont initialisés et non vides.
+- Conversion du `robotstxt` interne en schéma Zod approprié et nettoyage du code associé.
+- Page d’éditeur mise à jour pour injecter également une variable d’identification pour la page actuelle.

--- a/src/content/docs/fr/how-it-works/index.mdx
+++ b/src/content/docs/fr/how-it-works/index.mdx
@@ -4,9 +4,6 @@ title: "L’intégration"
 description: "Découvrez comment StudioCMS vous aide à gérer et à diffuser votre contenu en explorant une présentation complète de ses composants fondamentaux."
 sidebar:
    order: 1
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 # Présentation

--- a/src/content/docs/fr/how-it-works/sdk.mdx
+++ b/src/content/docs/fr/how-it-works/sdk.mdx
@@ -60,5 +60,7 @@ const {
    GET,
    POST,
    UPDATE,
+   PLUGINS,
+   MIDDLEWARES,
 } = SDKCoreJs;
 ```

--- a/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-wysiwyg.mdx
+++ b/src/content/docs/fr/package-catalog/studiocms-plugins/studiocms-wysiwyg.mdx
@@ -6,8 +6,8 @@ catalogEntry: studiocms-wysiwyg
 description: "Ajoutez facilement un éditeur WYSIWYG à votre projet StudioCMS !"
 sidebar:
   badge: 
-    text: 'Expérimental'
-    variant: 'danger'
+    text: 'Module d’extension'
+    variant: 'tip'
 ---
 
 import { PackageManagers } from 'starlight-package-managers'

--- a/src/content/docs/fr/plugins/index.mdx
+++ b/src/content/docs/fr/plugins/index.mdx
@@ -4,9 +4,6 @@ title: Les fondamentaux
 description: Découvrez les modules d’extension de StudioCMS et leur fonctionnement.
 sidebar:
    order: 1
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 import ReadMore from '~/components/ReadMore.astro'

--- a/src/content/docs/fr/start-here/getting-started.mdx
+++ b/src/content/docs/fr/start-here/getting-started.mdx
@@ -4,9 +4,6 @@ title: Mise en route
 description: Soyez prêt à construire avec StudioCMS.
 sidebar:
    order: 1
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 import { PackageManagers } from 'starlight-package-managers'

--- a/src/content/docs/fr/utils/rendering.mdx
+++ b/src/content/docs/fr/utils/rendering.mdx
@@ -4,9 +4,6 @@ title: "Rendu du contenu"
 description: "Options de rendu du contenu."
 sidebar:
    order: 1
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 import { Aside } from '@astrojs/starlight/components'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #158 to the French translation:
* translate `0-1-0-beta-24.mdx`
* remove/update the badge in some other files
* add two exports in `sdk.mdx`

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added French upgrade guide for 0.1.0-beta.24 with migration steps and highlighted breaking changes.
  - Updated SDK docs to reflect new PLUGINS and MIDDLEWARES exports.
  - Standardized frontmatter by removing “Mis à jour/NOUVEAU” sidebar badges across several French pages.
  - Revised WYSIWYG plugin page badge to “Module d’extension” with a friendlier style.
  - Minor cleanup and consistency improvements in French docs (no content changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->