### PR TITLE
i18n(fr): update docs for beta 25

### DIFF
--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-24.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-24.mdx
@@ -4,9 +4,6 @@ title: "Mise à niveau : 0.1.0-beta.24"
 description: Mettre à niveau StudioCMS vers la version Beta.24
 sidebar:
   label: 0.1.0-beta.24
-  badge:
-    text: NOUVEAU
-    variant: success
   order: 999991
 ---
 

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-25.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-25.mdx
@@ -1,0 +1,32 @@
+---
+i18nReady: true
+title: "Mise à niveau : 0.1.0-beta.25"
+description: Mettre à niveau StudioCMS vers la version Beta.25
+sidebar:
+  label: 0.1.0-beta.25
+  badge:
+    text: NOUVEAU
+    variant: success
+  order: 999990
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import QuickUpdate from '~/components/QuickUpdate.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+<QuickUpdate />
+
+## Fonctionnalités
+
+- Refonte des composants de gestion de contenu du tableau de bord pour éliminer les scripts incorporés et améliorer la réutilisabilité du code.
+- Refonte de l’emploi d’Effect pour utiliser les nouveaux utilitaires améliorés du nouveau paquet `@withstudiocms/effect`.
+- Mise à jour pour utiliser le nouveau paquet `@withstudiocms/component-registry`.
+- Migre les routes d’API vers le nouvel utilitaire createEffectAPIRoutes depuis `@withstudiocms/effect`.
+- Optimise l’aperçu de la page de connexion sur la page de configuration et la première mise en route.
+- Optimise la page de connexion utilisant `threejs`, pour garantir un chargement rapide de la page.
+
+## Corrections de bugs
+
+- Unifie la configuration date-heure lors de la dernière vérification de mise à jour pour la modale de vérification de version.
+- Nettoie le code, corrige la première configuration d’OAuth et nettoie les anciens utilitaires.
+- Consolide les définitions de table dans la configuration et supprime le fichier de tables hérité.

--- a/src/content/docs/fr/how-it-works/effect.mdx
+++ b/src/content/docs/fr/how-it-works/effect.mdx
@@ -4,6 +4,9 @@ title: "Effect"
 description: "Découvrez comment StudioCMS utilise Effect."
 sidebar:
    order: 5
+   badge:
+     text: Mis à jour
+     variant: success
 ---
 
 import ReadMore from '~/components/ReadMore.astro';
@@ -26,7 +29,7 @@ Cela inclut exactement les mêmes exportations de base que l’exportation par d
 
 ```ts twoslash title="custom-utils.ts"
 import { 
-   convertToVanilla, errorTap, 
+   runEffect, errorTap, 
    genLogger, pipeLogger, 
    runtimeLogger 
 } from 'studiocms/effect';

--- a/src/content/docs/fr/how-it-works/effect.mdx
+++ b/src/content/docs/fr/how-it-works/effect.mdx
@@ -37,4 +37,4 @@ import {
 
 ## Ressources
 
-<ReadMore>Vous souhaitez en savoir plus sur Effect ? Consultez la documentation d’Effect (https://effect.website/docs/getting-started/introduction/).</ReadMore>
+<ReadMore>Vous souhaitez en savoir plus sur Effect ? Consultez la [documentation d’Effect](https://effect.website/docs/getting-started/introduction/).</ReadMore>

--- a/src/content/docs/fr/how-it-works/sdk.mdx
+++ b/src/content/docs/fr/how-it-works/sdk.mdx
@@ -4,9 +4,6 @@ title: "Le SDK"
 description: "Découvrez le SDK de StudioCMS et comment l’utiliser."
 sidebar:
    order: 3
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 import ReadMore from '~/components/ReadMore.astro';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #160 to the French translation:
* translate the new version guide
* update some badges
* update a code snippet

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new French upgrade guide for 0.1.0-beta.25 with feature and bug-fix notes (sidebar shows a NOUVEAU badge).
  * Updated the Effect doc example to reflect the renamed API symbol and refreshed resource link.
  * Added a “Mis à jour” badge to one how‑it‑works page.
  * Removed outdated “NOUVEAU”/“Mis à jour” badges from other French pages.
  * No functional changes; content and presentation updates only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->