### PR TITLE
i18n(fr): update docs for beta 26

### DIFF
--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-25.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-25.mdx
@@ -5,8 +5,6 @@ description: Mettre à niveau StudioCMS vers la version Beta.25
 sidebar:
   label: 0.1.0-beta.25
   badge:
-    text: NOUVEAU
-    variant: success
   order: 999990
 ---
 

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-25.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-25.mdx
@@ -4,7 +4,6 @@ title: "Mise à niveau : 0.1.0-beta.25"
 description: Mettre à niveau StudioCMS vers la version Beta.25
 sidebar:
   label: 0.1.0-beta.25
-  badge:
   order: 999990
 ---
 

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-26.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-26.mdx
@@ -22,7 +22,7 @@ import { Aside } from '@astrojs/starlight/components'
    - Implémente une nouvelle table de base de données pour l’enregistrement de configuration dynamique dans une table unifiée.
    - Configuration de la table AstroDB mise à jour pour utiliser les énumérations pour les autorisations.
 - Supprime dans `locals` les propriétés dépréciées du middleware au profit d’un objet StudioCMS dans `locals`.
-   - Noms de propriétés Astro.Locals de niveau supérieur supprimées :
+   - Noms de propriétés Astro.locals de niveau supérieur supprimées :
       - `SCMSGenerator`, `SCMSUiGenerator`, `latestVersion`, `siteConfig`, `defaultLang`, `routeMap`
       - `userSessionData`, `emailVerificationEnabled`, `userPermissionLevel`
       - `wysiwygCsrfToken` (renommée)

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-26.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-26.mdx
@@ -1,0 +1,59 @@
+---
+i18nReady: true
+title: "Mise à niveau : 0.1.0-beta.26"
+description: Mettre à niveau StudioCMS vers la version Beta.26
+sidebar:
+  label: 0.1.0-beta.26
+  badge:
+    text: NOUVEAU
+    variant: success
+  order: 999989
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import QuickUpdate from '~/components/QuickUpdate.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+<QuickUpdate />
+
+## Modifications avec rupture de compatibilité
+
+- Schéma de table Astro DB mis à jour (les utilisateurs devront exécuter `astro db push --remote` pour mettre à jour leur schéma de table)
+   - Implémente une nouvelle table de base de données pour l’enregistrement de configuration dynamique dans une table unifiée.
+   - Configuration de la table AstroDB mise à jour pour utiliser les énumérations pour les autorisations.
+- Supprime dans `locals` les propriétés dépréciées du middleware au profit d’un objet StudioCMS dans `locals`.
+   - Noms de propriétés Astro.Locals de niveau supérieur supprimées :
+      - `SCMSGenerator`, `SCMSUiGenerator`, `latestVersion`, `siteConfig`, `defaultLang`, `routeMap`
+      - `userSessionData`, `emailVerificationEnabled`, `userPermissionLevel`
+      - `wysiwygCsrfToken` (renommée)
+   - Nouvel emplacement :
+      - Accédez-y sous `Astro.locals.StudioCMS`.
+   - Renommage :
+      - `wysiwygCsrfToken` → `editorCSRFToken` (sous StudioCMS)
+   - Exemples de migration :
+      - Avant :
+         ```ts
+         const { siteConfig, defaultLang } = Astro.locals;
+         ```
+      - Après :
+         ```ts
+         const { siteConfig, defaultLang } = Astro.locals.StudioCMS;
+         ```
+
+      - Avant :
+         ```ts
+         const token = Astro.locals.wysiwygCsrfToken;
+         ```
+      - Après :
+         ```ts
+         const token = Astro.locals.StudioCMS.editorCSRFToken;
+         ```
+
+## Fonctionnalités
+
+- Mise à jour vers `@studiocms/ui` 1.0 beta.
+
+## Corrections de bugs
+
+- Ajuste la recherche de page SDK pour renvoyer `undefined` lorsqu’une page n’est pas trouvée, éliminant ainsi les erreurs Astro bruyantes en mode développement.
+- Corrige la conversion des données du formulaire lors de la première configuration.

--- a/src/content/docs/fr/how-it-works/effect.mdx
+++ b/src/content/docs/fr/how-it-works/effect.mdx
@@ -4,9 +4,6 @@ title: "Effect"
 description: "Découvrez comment StudioCMS utilise Effect."
 sidebar:
    order: 5
-   badge:
-     text: Mis à jour
-     variant: success
 ---
 
 import ReadMore from '~/components/ReadMore.astro';


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #162 to the French translation.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a new French upgrade guide for v0.1.0-beta.26 covering breaking changes, migration steps, and highlights of features and bug fixes.
  - Clarifies required database schema update (remote push) and updated application API surface and token renaming with migration examples.
  - Removed “NEW/Updated” sidebar badges from related French docs to streamline presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->