### PR TITLE
i18n(fr): update docs for beta.27

### DIFF
--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-26.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-26.mdx
@@ -4,9 +4,6 @@ title: "Mise à niveau : 0.1.0-beta.26"
 description: Mettre à niveau StudioCMS vers la version Beta.26
 sidebar:
   label: 0.1.0-beta.26
-  badge:
-    text: NOUVEAU
-    variant: success
   order: 999989
 ---
 

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-27.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-1-0-beta-27.mdx
@@ -1,0 +1,30 @@
+---
+i18nReady: true
+title: "Mise à niveau : 0.1.0-beta.27"
+description: Mettre à niveau StudioCMS vers la version Beta.27
+sidebar:
+  label: 0.1.0-beta.27
+  badge:
+    text: NOUVEAU
+    variant: success
+  order: 999988
+---
+
+import ReadMore from '~/components/ReadMore.astro'
+import QuickUpdate from '~/components/QuickUpdate.astro'
+import { Aside } from '@astrojs/starlight/components'
+
+<QuickUpdate />
+
+## Nouvelles fonctionnalités
+
+- Refaçonne la CLI afin d’utiliser le nouveau module Clack pour Effect à partir de `@withstudiocms/effect`
+- Migre la CLI vers le nouveau paquet `@withstudiocms/auth-kit`
+- Configuration des tests initiaux pour StudioCMS.
+
+## Corrections de bugs
+
+- Active le bouton « Brouillon » sur la page d’édition pour toutes les pages (y compris la page d’index) afin que le champ brouillon soit soumis avec le formulaire. Auparavant, le contrôle désactivé omettait ce champ de la charge utile, empêchant ainsi toute modification du statut de brouillon.
+- Vérifie que le slug n’est pas une chaîne de caractères vide ou un slug non valide.
+- Renomme le fichier interne pour éviter toute confusion avec les tests pendant le développement.
+- Corrige un paramètre dans la commande d’ajout de la CLI.

--- a/src/content/docs/fr/how-it-works/effect.mdx
+++ b/src/content/docs/fr/how-it-works/effect.mdx
@@ -25,11 +25,7 @@ import { Effect, Context, Schema, Data } from 'studiocms/effect';
 Cela inclut exactement les mêmes exportations de base que l’exportation par défaut d’Effect `import {} from 'effect';` ainsi que d'autres utilitaires utiles fournis par `effect/Function` et des utilitaires personnalisés de StudioCMS.
 
 ```ts twoslash title="custom-utils.ts"
-import { 
-   runEffect, errorTap, 
-   genLogger, pipeLogger, 
-   runtimeLogger 
-} from 'studiocms/effect';
+import { runEffect, genLogger, pipeLogger, runtimeLogger } from 'studiocms/effect';
 ```
 
 ## Ressources


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Adds changes from #165 to the French translation of the docs:
* translate the beta.27 upgrade guide
* remove the badge from beta.26
* update a code snippet in `how-it-works/effect`

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the French upgrade guide for 0.1.0-beta.26 by removing the “NOUVEAU” badge from the sidebar label.
  * Added a new French upgrade guide for 0.1.0-beta.27, including front matter, quick update highlights, and sections for new features and bug fixes.
  * Refreshed the “How it works: Effects” French documentation to align with current APIs, removing references to an outdated import and keeping examples consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->