### PR TITLE
Fix studicms crypto gen-jwt command guide

### DIFF
--- a/src/content/docs/de/guides/database/sqld-server.mdx
+++ b/src/content/docs/de/guides/database/sqld-server.mdx
@@ -53,7 +53,7 @@ Dadurch wird ein neues PKCS#8-Schlüsselpaar erzeugt, das für den `sqld`-Server
 
 Navigiere zu deinem studiocms-Projektverzeichnis und führe den folgenden Befehl aus:
 
-<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -c "iss=admin" -e 31556926' />
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt -e 31556926 "../keys/libsql.pem"' />
 
 Die Ausgabe ist das mit deinem privaten Schlüssel verschlüsselte JWT-Auth-Token, das für die libSQL-Authentifizierung verwendet wird. Beachte, dass das Token 1 Jahr lang gültig ist!
 

--- a/src/content/docs/en/guides/database/sqld-server.mdx
+++ b/src/content/docs/en/guides/database/sqld-server.mdx
@@ -52,7 +52,7 @@ This will generate a new PKCS#8 key-pair that will be used for the `sqld` server
 
 Navigate to your studiocms project directory and run the following command:
 
-<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -e 31556926' />
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt -e 31556926 "../keys/libsql.pem"' />
 
 The output is the JWT auth token encrypted with your private key in both standard format as well as base64URLEncoded, which will be used for libSQL authentication. Keep in mind that the token will be valid for 1 year!
 

--- a/src/content/docs/es/guides/database/sqld-server.mdx
+++ b/src/content/docs/es/guides/database/sqld-server.mdx
@@ -54,7 +54,7 @@ Esto generará un nuevo par de claves PKCS#8 que se utilizarán para el servidor
 
 Navega a tu directorio del proyecto studiocms y ejecuta el siguiente comando:
 
-<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -c "iss=admin" -e 31556926' />
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt -e 31556926 "../keys/libsql.pem"' />
 
 El resultado es el token de autenticación JWT cifrado con tu clave privada, que se utilizará para la autenticación de libSQL. Ten en cuenta que el token será válido durante 1 año.
 

--- a/src/content/docs/fr/guides/database/sqld-server.mdx
+++ b/src/content/docs/fr/guides/database/sqld-server.mdx
@@ -52,7 +52,7 @@ Cela générera une nouvelle paire de clés PKCS#8 qui sera utilisée pour le se
 
 Accédez au répertoire de votre projet StudioCMS et exécutez la commande suivante :
 
-<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -e 31556926' />
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt -e 31556926 "../keys/libsql.pem"' />
 
 Le résultat est le jeton d'authentification JWT chiffré avec votre clé privée au format standard et encodé en tant que `base64URL`, qui sera utilisé pour l’authentification libSQL. Gardez à l’esprit que le token sera valable 1 an !
 

--- a/src/content/docs/ko/guides/database/sqld-server.mdx
+++ b/src/content/docs/ko/guides/database/sqld-server.mdx
@@ -52,7 +52,7 @@ openssl pkey -in ./libsql.pem -pubout -out ./libsql.pub
 
 StudioCMS 프로젝트 디렉터리로 이동하여 다음 명령을 실행합니다.
 
-<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -c "iss=admin" -e 31556926' />
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt -e 31556926 "../keys/libsql.pem" ' />
 
 출력된 내용은 개인 키로 암호화된 JWT 인증 토큰이며, 이는 libSQL 인증에 사용됩니다. 이 토큰은 1년 동안 유효하다는 점을 유념하세요!
 

--- a/src/content/docs/zh-cn/guides/database/sqld-server.mdx
+++ b/src/content/docs/zh-cn/guides/database/sqld-server.mdx
@@ -51,7 +51,7 @@ openssl pkey -in ./libsql.pem -pubout -out ./libsql.pub
 
 进入 StudioCMS 项目目录并执行：
 
-<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -e 31556926' />
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt -e 31556926 "../keys/libsql.pem"' />
 
 输出包含标准格式和 Base64URL 编码的 JWT 认证令牌，用于 libSQL 身份验证。该令牌有效期为 1 年！
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

The command inside the [Database Guides > Self-hosted libSQL server > Generate your JWT token](https://docs.studiocms.dev/en/guides/database/sqld-server/#generate-your-jwt-token) section is throwing an error, with the reason that the -e parameter should come before the key file path.

Please note that the fix is applied to all language files, which had also differences between each other and the default English version.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->