### PR TITLE
fix: gen-jwt command guide fixed (en)

### DIFF
--- a/src/content/docs/en/guides/database/sqld-server.mdx
+++ b/src/content/docs/en/guides/database/sqld-server.mdx
@@ -52,7 +52,7 @@ This will generate a new PKCS#8 key-pair that will be used for the `sqld` server
 
 Navigate to your studiocms project directory and run the following command:
 
-<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt "../keys/libsql.pem" -e 31556926' />
+<PackageManagers pkg='studiocms' type='run' args='crypto gen-jwt -e 31556926 "../keys/libsql.pem"' />
 
 The output is the JWT auth token encrypted with your private key in both standard format as well as base64URLEncoded, which will be used for libSQL authentication. Keep in mind that the token will be valid for 1 year!
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

The command inside the [Database Guides > Self-hosted libSQL server > Generate your JWT token](https://docs.studiocms.dev/en/guides/database/sqld-server/#generate-your-jwt-token) section is throwing an error, with the reason that the -e parameter should come before the key file path.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sqld-server guide to reflect the correct command syntax for generating JWTs, placing the expiration flag before the private key argument.
  * Clarified the example invocation to improve readability and reduce potential confusion when copying commands.
  * Ensured consistency across documentation by aligning argument order with recommended usage.
  * No behavioral changes to tooling implied; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->