### PR TITLE
i18n(fr): add `version-guides/0-4-3.mdx`

### DIFF
--- a/src/content/docs/fr/guides/upgrade/version-guides/0-4-3.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-4-3.mdx
@@ -1,0 +1,27 @@
+---
+i18nReady: true
+title: "Mise à niveau : v0.4.3"
+description: Mettre à niveau StudioCMS vers la v0.4.3
+topic: guides
+sidebar:
+  label: v0.4.3
+  badge:
+    text: NOUVEAU
+    variant: success
+  order: 999977
+---
+
+import QuickUpdate from '~/components/QuickUpdate.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+<QuickUpdate />
+
+<Aside variant="note" title='Note concernant Astro v6'>
+Bien qu'Astro v6 soit sorti récemment, StudioCMS ne sera pas compatible avec Astro v6 avant une future version. Nous vous recommandons d'attendre que StudioCMS annonce la compatibilité avant de mettre à niveau vers Astro v6, ce qui devrait se produire quelques semaines après la sortie d'Astro v6.
+</Aside>
+
+## Corrections de bugs et améliorations
+- Corrige et ajuste les dépendances homologues (`peerDependencies`) pour StudioCMS afin de garantir que `effect`, `@effect/platform` et `@effect/platform-node` sont tous correctement inclus en tant que dépendances homologues requises pour StudioCMS.
+- Améliore la gestion de la vérification du rang pour le point de terminaison `createUser` de l'API REST
+- Corrige le point de terminaison `createResetLink` de l'API du tableau de bord pour valider correctement les classements.
+- Corrige le point de terminaison de notification des utilisateurs de l'API du tableau de bord afin d'empêcher les utilisateurs non autorisés de modifier les notifications d'autres utilisateurs.

--- a/src/content/docs/fr/guides/upgrade/version-guides/0-4-3.mdx
+++ b/src/content/docs/fr/guides/upgrade/version-guides/0-4-3.mdx
@@ -17,11 +17,11 @@ import { Aside } from '@astrojs/starlight/components';
 <QuickUpdate />
 
 <Aside variant="note" title='Note concernant Astro v6'>
-Bien qu'Astro v6 soit sorti récemment, StudioCMS ne sera pas compatible avec Astro v6 avant une future version. Nous vous recommandons d'attendre que StudioCMS annonce la compatibilité avant de mettre à niveau vers Astro v6, ce qui devrait se produire quelques semaines après la sortie d'Astro v6.
+Bien qu’Astro v6 soit sorti récemment, StudioCMS ne sera pas compatible avec Astro v6 avant une future version. Nous vous recommandons d’attendre que StudioCMS annonce la compatibilité avant de mettre à niveau vers Astro v6, ce qui devrait se produire quelques semaines après la sortie d’Astro v6.
 </Aside>
 
 ## Corrections de bugs et améliorations
 - Corrige et ajuste les dépendances homologues (`peerDependencies`) pour StudioCMS afin de garantir que `effect`, `@effect/platform` et `@effect/platform-node` sont tous correctement inclus en tant que dépendances homologues requises pour StudioCMS.
-- Améliore la gestion de la vérification du rang pour le point de terminaison `createUser` de l'API REST
-- Corrige le point de terminaison `createResetLink` de l'API du tableau de bord pour valider correctement les classements.
-- Corrige le point de terminaison de notification des utilisateurs de l'API du tableau de bord afin d'empêcher les utilisateurs non autorisés de modifier les notifications d'autres utilisateurs.
+- Améliore la gestion de la vérification du rang pour le point de terminaison `createUser` de l’API REST
+- Corrige le point de terminaison `createResetLink` de l’API du tableau de bord pour valider correctement les classements.
+- Corrige le point de terminaison de notification des utilisateurs de l’API du tableau de bord afin d’empêcher les utilisateurs non autorisés de modifier les notifications d’autres utilisateurs.


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

Translates in French the new `version-guides/0-4-3.mdx` page added in #246

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced French-language upgrade guide for StudioCMS v0.4.3 with comprehensive documentation of endpoint and security-related bug fixes and improvements.
  * Added compatibility notice: StudioCMS is not yet compatible with Astro v6.

* **Chores**
  * Updated peer dependency version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->